### PR TITLE
Replaced `react` with `preact` in production bundle

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,20 +3,34 @@ module.exports = {
     return [
       {
         source: '/sitemap.xml',
-        destination: '/api/sitemap'
-      }
+        destination: '/api/sitemap',
+      },
     ];
   },
   images: {
     domains: [
       's3.us-west-2.amazonaws.com', // Images coming from Notion
       'via.placeholder.com', // for articles that do not have a cover image
-      'images.unsplash.com', // For blog posts that use an external cover image
+      'images.unsplash.com', // For blog posts that use an external cover ima ge
       'pbs.twimg.com', // Twitter Profile Picture
       'dwgyu36up6iuz.cloudfront.net',
       'cdn.hashnode.com',
       'res.craft.do',
-      'res.cloudinary.com'
-    ]
-  }
+      'res.cloudinary.com',
+    ],
+  },
+  webpack: (config, { dev, isServer }) => {
+    // Replace React with Preact only in client production build.
+    // With this you ship way less javascript to the client I mean almost half.
+    if (!dev && !isServer) {
+      Object.assign(config.resolve.alias, {
+        react: 'preact/compat',
+        'react-dom/test-utils': 'preact/test-utils',
+        'react-dom': 'preact/compat',
+        'react/jsx-runtime': 'preact/jsx-runtime',
+      });
+    }
+
+    return config;
+  },
 };

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "copy-to-clipboard": "^3.3.1",
     "framer-motion": "^5.4.1",
     "next": "^12.0.4",
+    "preact": "^10.6.4",
     "next-plausible": "^3.0.0",
     "next-themes": "0.0.15",
     "prism-react-renderer": "^1.2.1",


### PR DESCRIPTION
Replace react with preact but only for production build, this way you ship more than 50% less javascript to the client.