### PR TITLE
Fix GitHub icon link on /links page

### DIFF
--- a/app/links/page.tsx
+++ b/app/links/page.tsx
@@ -138,7 +138,7 @@ export default async function LinksPage() {
               </div>
             </a>
             <a
-              href={siteMetadata.linkedin}
+              href={siteMetadata.github}
               target="_blank"
               rel="noopener noreferrer"
               className="group no-underline transition-all duration-500 group-hover:-translate-y-3"


### PR DESCRIPTION
Updated the GitHub social icon to point to GitHub profile instead of LinkedIn profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)