### PR TITLE
Fix laggy animations on mobile /stats page

### DIFF
--- a/app/components/stats/CategoryBarChart.tsx
+++ b/app/components/stats/CategoryBarChart.tsx
@@ -3,6 +3,7 @@
 import { motion } from "framer-motion";
 import { useState } from "react";
 import type { CategoryCount } from "@/app/lib/stats/types";
+import { usePerformanceMode } from "@/app/hooks/usePerformanceMode";
 
 interface CategoryBarChartProps {
   categories: CategoryCount[];
@@ -22,17 +23,70 @@ export function CategoryBarChart({
   categories,
   delay = 0,
 }: CategoryBarChartProps) {
+  const { shouldReduceAnimations } = usePerformanceMode();
   const [isHovered, setIsHovered] = useState(false);
   const [hoveredBar, setHoveredBar] = useState<number | null>(null);
   const maxCount = Math.max(...categories.map((c) => c.count), 1);
   const displayCategories = categories.slice(0, 6);
 
+  const cardClassName = "group relative flex h-full flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary p-6 transition-all duration-300 hover:border-indigo-400 hover:bg-white";
+
+  // Mobile: Plain div (zero animation overhead)
+  if (shouldReduceAnimations) {
+    return (
+      <div className={cardClassName}>
+        {/* Hover gradient overlay */}
+        <div className="pointer-events-none absolute inset-0 z-10 rounded-2xl bg-gradient-to-tl from-indigo-400/20 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+
+        <div className="relative z-20 flex h-full flex-col">
+          <h2 className="mb-2 font-medium text-text-primary">Categories</h2>
+          <p className="mb-4 text-sm text-text-secondary">
+            Articles by topic
+          </p>
+
+          <div className="flex flex-1 flex-col justify-center space-y-3">
+            {displayCategories.map((category, index) => {
+              const percentage = (category.count / maxCount) * 100;
+              const color = BAR_COLORS[index % BAR_COLORS.length];
+
+              return (
+                <div key={category.name} className="group/bar">
+                  <div className="mb-1 flex items-center justify-between">
+                    <span className="truncate text-xs font-medium text-text-secondary">
+                      {category.name}
+                    </span>
+                    <span className="ml-2 shrink-0 text-xs font-semibold tabular-nums text-text-tertiary">
+                      {category.count}
+                    </span>
+                  </div>
+                  <div className="relative h-3 w-full overflow-hidden rounded-full bg-border-primary/30">
+                    <div
+                      style={{ width: `${percentage}%` }}
+                      className={`absolute inset-y-0 left-0 origin-left rounded-full ${color}`}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {categories.length > 6 && (
+            <p className="mt-4 text-xs text-text-tertiary opacity-60">
+              +{categories.length - 6} more categories
+            </p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // Desktop: Full Framer Motion animations
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5, delay, ease: "easeOut" }}
-      className="group relative flex h-full flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary p-6 transition-all duration-300 hover:border-indigo-400 hover:bg-white"
+      className={cardClassName}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >

--- a/app/components/stats/ChangelogUpdatesCard.tsx
+++ b/app/components/stats/ChangelogUpdatesCard.tsx
@@ -4,6 +4,7 @@ import { motion } from "framer-motion";
 import Link from "next/link";
 import { useState, useEffect } from "react";
 import { changelogItems } from "#site/content";
+import { usePerformanceMode } from "@/app/hooks/usePerformanceMode";
 
 interface ChangelogUpdatesCardProps {
   count: number;
@@ -14,6 +15,7 @@ export function ChangelogUpdatesCard({
   count,
   delay = 0,
 }: ChangelogUpdatesCardProps) {
+  const { shouldReduceAnimations } = usePerformanceMode();
   const [isHovered, setIsHovered] = useState(false);
   const [displayCount, setDisplayCount] = useState(0);
 
@@ -26,6 +28,11 @@ export function ChangelogUpdatesCard({
     .slice(0, 8);
 
   useEffect(() => {
+    if (shouldReduceAnimations) {
+      setDisplayCount(count);
+      return;
+    }
+
     const duration = 1500;
     const startTime = performance.now();
     const startDelay = delay * 1000;
@@ -48,7 +55,7 @@ export function ChangelogUpdatesCard({
     };
 
     requestAnimationFrame(animateCount);
-  }, [count, delay]);
+  }, [count, delay, shouldReduceAnimations]);
 
   const getTopPosition = (index: number) => {
     const basePosition = -5;
@@ -56,13 +63,105 @@ export function ChangelogUpdatesCard({
     return `${basePosition + index * spacing}px`;
   };
 
+  const cardClassName = "group relative flex h-full flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary p-6 transition-all duration-300 hover:border-indigo-400 hover:bg-white";
+
+  // Mobile: Plain div (zero animation overhead)
+  if (shouldReduceAnimations) {
+    return (
+      <Link href="/changelog" className="block h-full">
+        <div className={cardClassName}>
+          {/* Hover gradient overlay */}
+          <div className="pointer-events-none absolute inset-0 z-30 rounded-2xl bg-gradient-to-tl from-indigo-400/20 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+
+          {/* Central vertical timeline - matching ChangelogBento */}
+          <div className="border-px absolute left-1/2 top-0 h-full w-2 -translate-x-1/2 transform border-x border-[#A5AEB8]/10 bg-[#D6DADE]/35" />
+
+          {/* Timeline entries */}
+          <div className="relative flex-1">
+            <div className="absolute left-0 right-0 top-0">
+              {recentItems.map((item, index) => (
+                <div
+                  key={item.publishedAt}
+                  className="absolute"
+                  style={{
+                    top: getTopPosition(index),
+                    ...(index % 2 === 1
+                      ? { left: "calc(50% + 6px)" }
+                      : { right: "calc(50% + 6px)" }),
+                  }}
+                >
+                  {/* Connecting line to timeline */}
+                  <span
+                    className={`absolute top-[14px] h-px w-[6px] bg-border-primary ${
+                      index % 2 === 1 ? "left-[-6px]" : "right-[-6px]"
+                    }`}
+                  />
+                  {/* Entry card */}
+                  <div className="z-10 inline-block w-[100px] space-y-px rounded-lg border border-border-primary bg-white px-2 py-1.5 text-xs shadow-sm">
+                    <p className="overflow-hidden text-ellipsis whitespace-nowrap font-semibold text-text-secondary">
+                      {item.title}
+                    </p>
+                    <time
+                      dateTime={item.publishedAt}
+                      className="text-[9px] text-text-tertiary"
+                    >
+                      {new Date(item.publishedAt).toLocaleDateString("en-US", {
+                        month: "short",
+                        day: "numeric",
+                      })}
+                    </time>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Gradient overlays for scroll effect */}
+          <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-10 bg-gradient-to-b from-bg-primary to-transparent transition-colors group-hover:from-white" />
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-32 bg-gradient-to-t from-bg-primary via-bg-primary/75 to-transparent transition-colors group-hover:from-white group-hover:via-white/75" />
+
+          {/* Content at bottom */}
+          <div className="relative z-20 mt-auto">
+            <h2 className="mb-1 font-medium text-text-primary">
+              Changelog
+            </h2>
+            <div className="flex items-baseline gap-2">
+              <span className="text-2xl font-bold tabular-nums tracking-tight text-purple-primary">
+                {displayCount}
+              </span>
+              <span className="text-sm text-text-tertiary">updates</span>
+            </div>
+          </div>
+
+          {/* Link arrow */}
+          <div className="absolute bottom-4 right-4 z-40 flex h-8 w-8 items-center justify-center rounded-full bg-indigo-100 opacity-0 transition-opacity group-hover:opacity-100">
+            <svg
+              className="h-4 w-4 text-indigo-600"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M7 17L17 7M17 7H7M17 7V17"
+              />
+            </svg>
+          </div>
+        </div>
+      </Link>
+    );
+  }
+
+  // Desktop: Full Framer Motion animations
   return (
     <Link href="/changelog" className="block h-full">
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5, delay, ease: "easeOut" }}
-        className="group relative flex h-full flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary p-6 transition-all duration-300 hover:border-indigo-400 hover:bg-white"
+        className={cardClassName}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
       >

--- a/app/components/stats/CoffeeCupsCard.tsx
+++ b/app/components/stats/CoffeeCupsCard.tsx
@@ -44,6 +44,9 @@ export function CoffeeCupsCard({ cups, delay = 0 }: CoffeeCupsCardProps) {
     requestAnimationFrame(animateCount);
   }, [cups, delay, shouldReduceAnimations]);
 
+  // Use actual value immediately if animations are reduced to prevent flash from 0
+  const effectiveDisplayCups = shouldReduceAnimations ? cups : displayCups;
+
   // Staggered coffee cup decorations
   const coffeeCups = [
     { x: "10%", y: "20%", rotate: -15, delay: 0 },
@@ -90,7 +93,7 @@ export function CoffeeCupsCard({ cups, delay = 0 }: CoffeeCupsCardProps) {
           <div className="mt-auto">
             <div className="flex items-baseline gap-1">
               <span className="text-3xl font-semibold tracking-tight text-purple-primary">
-                ~{displayCups.toLocaleString()}
+                ~{effectiveDisplayCups.toLocaleString()}
               </span>
               <span className="text-sm text-text-secondary">cups</span>
             </div>
@@ -167,7 +170,7 @@ export function CoffeeCupsCard({ cups, delay = 0 }: CoffeeCupsCardProps) {
             className="flex items-baseline gap-1"
           >
             <span className="text-3xl font-semibold tracking-tight text-purple-primary">
-              ~{displayCups.toLocaleString()}
+              ~{effectiveDisplayCups.toLocaleString()}
             </span>
             <span className="text-sm text-text-secondary">cups</span>
           </motion.div>

--- a/app/components/stats/CoffeeCupsCard.tsx
+++ b/app/components/stats/CoffeeCupsCard.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "framer-motion";
 import { useEffect, useState } from "react";
+import { usePerformanceMode } from "@/app/hooks/usePerformanceMode";
 
 interface CoffeeCupsCardProps {
   cups: number;
@@ -9,10 +10,16 @@ interface CoffeeCupsCardProps {
 }
 
 export function CoffeeCupsCard({ cups, delay = 0 }: CoffeeCupsCardProps) {
+  const { shouldReduceAnimations } = usePerformanceMode();
   const [isHovered, setIsHovered] = useState(false);
   const [displayCups, setDisplayCups] = useState(0);
 
   useEffect(() => {
+    if (shouldReduceAnimations) {
+      setDisplayCups(cups);
+      return;
+    }
+
     const duration = 1500;
     const startTime = performance.now();
     const startDelay = delay * 1000;
@@ -35,7 +42,7 @@ export function CoffeeCupsCard({ cups, delay = 0 }: CoffeeCupsCardProps) {
     };
 
     requestAnimationFrame(animateCount);
-  }, [cups, delay]);
+  }, [cups, delay, shouldReduceAnimations]);
 
   // Staggered coffee cup decorations
   const coffeeCups = [
@@ -45,12 +52,64 @@ export function CoffeeCupsCard({ cups, delay = 0 }: CoffeeCupsCardProps) {
     { x: "15%", y: "70%", rotate: 12, delay: 0.3 },
   ];
 
+  const cardClassName = "group relative flex h-full flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary p-6 transition-all duration-300 hover:border-indigo-400 hover:bg-white";
+
+  // Mobile: Plain div (zero animation overhead)
+  if (shouldReduceAnimations) {
+    return (
+      <div className={cardClassName}>
+        {/* Hover gradient overlay */}
+        <div className="pointer-events-none absolute inset-0 z-10 rounded-2xl bg-gradient-to-tl from-indigo-400/20 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+
+        {/* Floating coffee cups */}
+        <div className="pointer-events-none absolute inset-0 overflow-hidden">
+          {coffeeCups.map((cup, i) => (
+            <span
+              key={i}
+              className="absolute text-2xl"
+              style={{
+                left: cup.x,
+                top: cup.y,
+                opacity: 0.15,
+                transform: `rotate(${cup.rotate}deg)`,
+              }}
+            >
+              ☕
+            </span>
+          ))}
+        </div>
+
+        <div className="relative z-20 flex h-full flex-col">
+          <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-xl bg-amber-100 text-xl">
+            ☕
+          </div>
+
+          <h2 className="mb-2 font-medium text-text-primary">Coffee Consumed</h2>
+          <p className="text-sm text-text-secondary">Estimated fuel</p>
+
+          <div className="mt-auto">
+            <div className="flex items-baseline gap-1">
+              <span className="text-3xl font-semibold tracking-tight text-purple-primary">
+                ~{displayCups.toLocaleString()}
+              </span>
+              <span className="text-sm text-text-secondary">cups</span>
+            </div>
+            <p className="mt-2 text-xs text-text-tertiary">
+              1 cup per 500 words
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Desktop: Full Framer Motion animations
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5, delay, ease: "easeOut" }}
-      className="group relative flex h-full flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary p-6 transition-all duration-300 hover:border-indigo-400 hover:bg-white"
+      className={cardClassName}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >

--- a/app/components/stats/CommunityMessagesCard.tsx
+++ b/app/components/stats/CommunityMessagesCard.tsx
@@ -3,6 +3,7 @@
 import { motion } from "framer-motion";
 import Link from "next/link";
 import { useState, useEffect } from "react";
+import { usePerformanceMode } from "@/app/hooks/usePerformanceMode";
 
 interface CommunityMessagesCardProps {
   count: number;
@@ -20,10 +21,16 @@ export function CommunityMessagesCard({
   count,
   delay = 0,
 }: CommunityMessagesCardProps) {
+  const { shouldReduceAnimations } = usePerformanceMode();
   const [isHovered, setIsHovered] = useState(false);
   const [displayCount, setDisplayCount] = useState(0);
 
   useEffect(() => {
+    if (shouldReduceAnimations) {
+      setDisplayCount(count);
+      return;
+    }
+
     const duration = 1500;
     const startTime = performance.now();
     const startDelay = delay * 1000;
@@ -46,15 +53,166 @@ export function CommunityMessagesCard({
     };
 
     requestAnimationFrame(animateCount);
-  }, [count, delay]);
+  }, [count, delay, shouldReduceAnimations]);
 
+  const cardClassName = "group relative flex h-full min-h-[340px] flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary p-6 transition-all duration-300 hover:border-indigo-400 hover:bg-white";
+
+  // Mobile: Plain div (zero animation overhead)
+  if (shouldReduceAnimations) {
+    return (
+      <Link href="/community-wall" className="block h-full">
+        <div className={cardClassName}>
+          {/* Dot pattern background */}
+          <div className="absolute inset-0 bg-[radial-gradient(#e5e7eb_1px,transparent_2px)] [background-size:16px_16px] [mask-image:radial-gradient(ellipse_50%_50%_at_50%_50%,#000_70%,transparent_100%)]" />
+
+          {/* Hover gradient overlay */}
+          <div className="pointer-events-none absolute inset-0 z-30 rounded-2xl bg-gradient-to-tl from-indigo-400/20 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+
+          {/* Stacked cards with fan-out animation */}
+          <div className="absolute inset-0 flex items-center justify-center pb-16">
+            <div className="relative h-32 w-40">
+              {miniCards.map((card, index) => (
+                <svg
+                  key={index}
+                  className="absolute left-1/2 top-1/2 w-36"
+                  style={{
+                    zIndex: index === 1 ? 3 : index === 2 ? 2 : 1,
+                    transform: `translate(calc(-50% + ${card.x * 0.6}px), calc(-50% + ${card.y * 0.5}px)) rotate(${card.rotate * 0.8}deg) scale(${1 - (2 - index) * 0.02})`,
+                    transformOrigin: "center",
+                  }}
+                  viewBox="-15 -15 160 155"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <defs>
+                    <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="100%">
+                      <stop offset="0%" stopColor="#90D2AA" />
+                      <stop offset="100%" stopColor="#FEFFB4" />
+                    </linearGradient>
+                    <linearGradient id="grad2" x1="0%" y1="0%" x2="100%" y2="100%">
+                      <stop offset="0%" stopColor="#C48EFF" />
+                      <stop offset="100%" stopColor="#FCCEED" />
+                    </linearGradient>
+                    <linearGradient id="grad3" x1="0%" y1="0%" x2="100%" y2="100%">
+                      <stop offset="0%" stopColor="#81E0CA" />
+                      <stop offset="100%" stopColor="#E9F2FE" />
+                    </linearGradient>
+                    <filter id={`shadow${index}`} x="-20%" y="-20%" width="150%" height="150%">
+                      <feDropShadow dx="4" dy="4" stdDeviation="8" floodOpacity="0.15" />
+                    </filter>
+                  </defs>
+
+                  {/* Card background with shadow */}
+                  <g filter={`url(#shadow${index})`}>
+                    <rect
+                      width="120"
+                      height="115"
+                      x="5"
+                      y="5"
+                      rx="8"
+                      fill="#F7F7F8"
+                    />
+                  </g>
+
+                  {/* Gradient header area */}
+                  <rect
+                    x="10"
+                    y="10"
+                    width="110"
+                    height="90"
+                    rx="4"
+                    fill={card.gradient}
+                    opacity="0.85"
+                  />
+
+                  {/* Decorative circles on gradient */}
+                  <circle cx="85" cy="35" r="25" fill="white" opacity="0.3" />
+                  <circle cx="40" cy="60" r="18" fill="white" opacity="0.2" />
+
+                  {/* Text lines */}
+                  <rect
+                    x="25"
+                    y="35"
+                    width="50"
+                    height="6"
+                    rx="3"
+                    fill="white"
+                    opacity={0.5}
+                  />
+                  <rect
+                    x="25"
+                    y="50"
+                    width="35"
+                    height="6"
+                    rx="3"
+                    fill="white"
+                    opacity={0.5}
+                  />
+
+                  {/* Avatar circle - left side */}
+                  <circle
+                    cx="26"
+                    cy="110"
+                    r="7"
+                    fill="#D1D5DB"
+                  />
+
+                  {/* User name line */}
+                  <rect
+                    x="40"
+                    y="106"
+                    width="50"
+                    height="7"
+                    rx="3"
+                    fill="#E5E7EB"
+                  />
+                </svg>
+              ))}
+            </div>
+          </div>
+
+          {/* Content at bottom */}
+          <div className="relative z-20 mt-auto">
+            <h2 className="mb-1 font-medium text-text-primary">
+              Community Messages
+            </h2>
+            <div className="flex items-baseline gap-2">
+              <span className="text-3xl font-bold tabular-nums tracking-tight text-purple-primary">
+                {displayCount.toLocaleString()}
+              </span>
+              <span className="text-sm text-text-tertiary">messages</span>
+            </div>
+          </div>
+
+          {/* Link arrow */}
+          <div className="absolute bottom-4 right-4 z-40 flex h-8 w-8 items-center justify-center rounded-full bg-indigo-100 opacity-0 transition-opacity group-hover:opacity-100">
+            <svg
+              className="h-4 w-4 text-indigo-600"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M7 17L17 7M17 7H7M17 7V17"
+              />
+            </svg>
+          </div>
+        </div>
+      </Link>
+    );
+  }
+
+  // Desktop: Full Framer Motion animations
   return (
     <Link href="/community-wall" className="block h-full">
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5, delay, ease: "easeOut" }}
-        className="group relative flex h-full min-h-[340px] flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary p-6 transition-all duration-300 hover:border-indigo-400 hover:bg-white"
+        className={cardClassName}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
       >

--- a/app/components/stats/ContributionGraphCard.tsx
+++ b/app/components/stats/ContributionGraphCard.tsx
@@ -3,6 +3,7 @@
 import { motion } from "framer-motion";
 import { useState, useEffect } from "react";
 import type { ContributionData, ContributionDay } from "@/app/lib/stats/types";
+import { usePerformanceMode } from "@/app/hooks/usePerformanceMode";
 
 interface ContributionGraphCardProps {
   contributions: ContributionData;
@@ -41,6 +42,7 @@ export function ContributionGraphCard({
   contributions,
   delay = 0,
 }: ContributionGraphCardProps) {
+  const { shouldReduceAnimations } = usePerformanceMode();
   const [isHovered, setIsHovered] = useState(false);
   const [displayCount, setDisplayCount] = useState(0);
   const [tooltip, setTooltip] = useState<{
@@ -50,15 +52,23 @@ export function ContributionGraphCard({
   } | null>(null);
 
   useEffect(() => {
+    // Skip expensive counting animation on mobile/reduced motion
+    if (shouldReduceAnimations) {
+      setDisplayCount(contributions.totalContributions);
+      return;
+    }
+
     const duration = 1500;
     const startTime = performance.now();
     const startDelay = delay * 1000;
+
+    let rafId: number;
 
     const animateCount = (currentTime: number) => {
       const elapsed = currentTime - startTime - startDelay;
 
       if (elapsed < 0) {
-        requestAnimationFrame(animateCount);
+        rafId = requestAnimationFrame(animateCount);
         return;
       }
 
@@ -67,12 +77,16 @@ export function ContributionGraphCard({
       setDisplayCount(Math.floor(eased * contributions.totalContributions));
 
       if (progress < 1) {
-        requestAnimationFrame(animateCount);
+        rafId = requestAnimationFrame(animateCount);
       }
     };
 
-    requestAnimationFrame(animateCount);
-  }, [contributions.totalContributions, delay]);
+    rafId = requestAnimationFrame(animateCount);
+
+    return () => {
+      if (rafId) cancelAnimationFrame(rafId);
+    };
+  }, [contributions.totalContributions, delay, shouldReduceAnimations]);
 
   // Get month labels for the graph
   const getMonthLabels = () => {
@@ -101,11 +115,15 @@ export function ContributionGraphCard({
 
   return (
     <motion.div
-      initial={{ opacity: 0, y: 20 }}
+      initial={shouldReduceAnimations ? false : { opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.5, delay, ease: "easeOut" }}
+      transition={
+        shouldReduceAnimations
+          ? { duration: 0 }
+          : { duration: 0.5, delay, ease: "easeOut" }
+      }
       className="group relative flex h-full min-h-[220px] flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary p-6 transition-all duration-300 hover:border-indigo-400 hover:bg-white"
-      onMouseEnter={() => setIsHovered(true)}
+      onMouseEnter={() => !shouldReduceAnimations && setIsHovered(true)}
       onMouseLeave={() => {
         setIsHovered(false);
         setTooltip(null);
@@ -118,7 +136,9 @@ export function ContributionGraphCard({
       <div className="relative z-20 mb-4 flex items-center justify-between">
         <div className="flex items-center gap-3">
           <motion.div
-            animate={{ y: isHovered ? -2 : 0 }}
+            animate={
+              shouldReduceAnimations ? {} : { y: isHovered ? -2 : 0 }
+            }
             transition={{ type: "spring", stiffness: 200, damping: 15 }}
             className="flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-100"
           >
@@ -136,7 +156,9 @@ export function ContributionGraphCard({
           </div>
         </div>
         <motion.div
-          animate={{ scale: isHovered ? 1.05 : 1 }}
+          animate={
+            shouldReduceAnimations ? {} : { scale: isHovered ? 1.05 : 1 }
+          }
           transition={{ type: "spring", stiffness: 300, damping: 20 }}
           className="text-right"
         >
@@ -194,13 +216,17 @@ export function ContributionGraphCard({
                 {contributions.weeks.map((week, weekIndex) => (
                   <motion.div
                     key={weekIndex}
-                    initial={{ opacity: 0, scale: 0.5 }}
+                    initial={shouldReduceAnimations ? false : { opacity: 0, scale: 0.5 }}
                     animate={{ opacity: 1, scale: 1 }}
-                    transition={{
-                      duration: 0.3,
-                      delay: delay + 0.3 + weekIndex * 0.005,
-                      ease: "easeOut",
-                    }}
+                    transition={
+                      shouldReduceAnimations
+                        ? { duration: 0 }
+                        : {
+                            duration: 0.3,
+                            delay: delay + 0.3 + weekIndex * 0.005,
+                            ease: "easeOut",
+                          }
+                    }
                     className="flex flex-col"
                     style={{ gap: "2px" }}
                   >
@@ -265,13 +291,17 @@ export function ContributionGraphCard({
               {contributions.weeks.map((week, weekIndex) => (
                 <motion.div
                   key={weekIndex}
-                  initial={{ opacity: 0, scale: 0.5 }}
+                  initial={shouldReduceAnimations ? false : { opacity: 0, scale: 0.5 }}
                   animate={{ opacity: 1, scale: 1 }}
-                  transition={{
-                    duration: 0.3,
-                    delay: delay + 0.3 + weekIndex * 0.005,
-                    ease: "easeOut",
-                  }}
+                  transition={
+                    shouldReduceAnimations
+                      ? { duration: 0 }
+                      : {
+                          duration: 0.3,
+                          delay: delay + 0.3 + weekIndex * 0.005,
+                          ease: "easeOut",
+                        }
+                  }
                   className="flex flex-col gap-[3px]"
                 >
                   {week.contributionDays.map((day, dayIndex) => (

--- a/app/components/stats/ContributionGraphCard.tsx
+++ b/app/components/stats/ContributionGraphCard.tsx
@@ -52,7 +52,7 @@ export function ContributionGraphCard({
   } | null>(null);
 
   useEffect(() => {
-    // Skip expensive counting animation on mobile/reduced motion
+    // Skip expensive counting animation for users with reduced motion preference
     if (shouldReduceAnimations) {
       setDisplayCount(contributions.totalContributions);
       return;

--- a/app/components/stats/ContributionGraphCard.tsx
+++ b/app/components/stats/ContributionGraphCard.tsx
@@ -112,36 +112,19 @@ export function ContributionGraphCard({
   };
 
   const monthLabels = getMonthLabels();
+  const cardClassName = "group relative flex h-full min-h-[220px] flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary p-6 transition-all duration-300 hover:border-indigo-400 hover:bg-white";
 
-  return (
-    <motion.div
-      initial={shouldReduceAnimations ? false : { opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={
-        shouldReduceAnimations
-          ? { duration: 0 }
-          : { duration: 0.5, delay, ease: "easeOut" }
-      }
-      className="group relative flex h-full min-h-[220px] flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary p-6 transition-all duration-300 hover:border-indigo-400 hover:bg-white"
-      onMouseEnter={() => !shouldReduceAnimations && setIsHovered(true)}
-      onMouseLeave={() => {
-        setIsHovered(false);
-        setTooltip(null);
-      }}
-    >
+  // Mobile: Plain div (zero animation overhead)
+  if (shouldReduceAnimations) {
+    return (
+      <div className={cardClassName}>
       {/* Hover gradient overlay */}
       <div className="pointer-events-none absolute inset-0 z-10 rounded-2xl bg-gradient-to-tl from-indigo-400/20 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
 
       {/* Header */}
       <div className="relative z-20 mb-4 flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <motion.div
-            animate={
-              shouldReduceAnimations ? {} : { y: isHovered ? -2 : 0 }
-            }
-            transition={{ type: "spring", stiffness: 200, damping: 15 }}
-            className="flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-100"
-          >
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-100">
             <svg
               className="h-5 w-5 text-emerald-600"
               fill="currentColor"
@@ -149,24 +132,18 @@ export function ContributionGraphCard({
             >
               <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
             </svg>
-          </motion.div>
+          </div>
           <div>
             <h2 className="font-medium text-text-primary">Contributions</h2>
             <p className="text-sm text-text-secondary">This year</p>
           </div>
         </div>
-        <motion.div
-          animate={
-            shouldReduceAnimations ? {} : { scale: isHovered ? 1.05 : 1 }
-          }
-          transition={{ type: "spring", stiffness: 300, damping: 20 }}
-          className="text-right"
-        >
+        <div className="text-right">
           <span className="text-2xl font-semibold tracking-tight text-purple-primary">
             {displayCount.toLocaleString()}
           </span>
           <p className="text-xs text-text-tertiary">contributions</p>
-        </motion.div>
+        </div>
       </div>
 
       {/* Contribution graph container */}
@@ -214,19 +191,8 @@ export function ContributionGraphCard({
               </div>
               <div className="flex" style={{ gap: "2px" }}>
                 {contributions.weeks.map((week, weekIndex) => (
-                  <motion.div
+                  <div
                     key={weekIndex}
-                    initial={shouldReduceAnimations ? false : { opacity: 0, scale: 0.5 }}
-                    animate={{ opacity: 1, scale: 1 }}
-                    transition={
-                      shouldReduceAnimations
-                        ? { duration: 0 }
-                        : {
-                            duration: 0.3,
-                            delay: delay + 0.3 + weekIndex * 0.005,
-                            ease: "easeOut",
-                          }
-                    }
                     className="flex flex-col"
                     style={{ gap: "2px" }}
                   >
@@ -249,7 +215,7 @@ export function ContributionGraphCard({
                         />
                       </div>
                     ))}
-                  </motion.div>
+                  </div>
                 ))}
               </div>
             </div>
@@ -289,19 +255,8 @@ export function ContributionGraphCard({
               }}
             >
               {contributions.weeks.map((week, weekIndex) => (
-                <motion.div
+                <div
                   key={weekIndex}
-                  initial={shouldReduceAnimations ? false : { opacity: 0, scale: 0.5 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  transition={
-                    shouldReduceAnimations
-                      ? { duration: 0 }
-                      : {
-                          duration: 0.3,
-                          delay: delay + 0.3 + weekIndex * 0.005,
-                          ease: "easeOut",
-                        }
-                  }
                   className="flex flex-col gap-[3px]"
                 >
                   {week.contributionDays.map((day, dayIndex) => (
@@ -323,7 +278,7 @@ export function ContributionGraphCard({
                       />
                     </div>
                   ))}
-                </motion.div>
+                </div>
               ))}
             </div>
           </div>
@@ -362,6 +317,186 @@ export function ContributionGraphCard({
           <div className="font-medium">
             {tooltip.day.contributionCount} contribution
             {tooltip.day.contributionCount !== 1 ? "s" : ""}
+          </div>
+          <div className="text-gray-400">{formatDate(tooltip.day.date)}</div>
+          <div className="absolute left-1/2 top-full -translate-x-1/2 border-4 border-transparent border-t-gray-900" />
+        </div>
+      )}
+    </div>
+    );
+  }
+
+  // Desktop: Full Framer Motion animations
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, delay, ease: "easeOut" }}
+      className={cardClassName}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => {
+        setIsHovered(false);
+        setTooltip(null);
+      }}
+    >
+      <div className="pointer-events-none absolute inset-0 z-10 rounded-2xl bg-gradient-to-tl from-indigo-400/20 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+
+      <div className="relative z-20 mb-4 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <motion.div
+            animate={{ y: isHovered ? -2 : 0 }}
+            transition={{ type: "spring", stiffness: 200, damping: 15 }}
+            className="flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-100"
+          >
+            <svg className="h-5 w-5 text-emerald-600" fill="currentColor" viewBox="0 0 16 16">
+              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+            </svg>
+          </motion.div>
+          <div>
+            <h2 className="font-medium text-text-primary">Contributions</h2>
+            <p className="text-sm text-text-secondary">This year</p>
+          </div>
+        </div>
+        <motion.div
+          animate={{ scale: isHovered ? 1.05 : 1 }}
+          transition={{ type: "spring", stiffness: 300, damping: 20 }}
+          className="text-right"
+        >
+          <span className="text-2xl font-semibold tracking-tight text-purple-primary">
+            {displayCount.toLocaleString()}
+          </span>
+          <p className="text-xs text-text-tertiary">contributions</p>
+        </motion.div>
+      </div>
+
+      <div className="relative z-20 mt-2 flex-1">
+        <div className="overflow-x-auto md:hidden">
+          <div className="w-fit">
+            <div className="mb-1 flex text-[10px] text-text-tertiary" style={{ paddingLeft: "28px" }}>
+              <div className="flex" style={{ gap: "2px" }}>
+                {contributions.weeks.map((week, weekIndex) => {
+                  const showMonth = monthLabels.some((m) => m.index === weekIndex);
+                  const monthLabel = showMonth ? monthLabels.find((m) => m.index === weekIndex)?.label : "";
+                  return (
+                    <div key={weekIndex} className="w-[10px] text-center">
+                      {monthLabel && <span className="whitespace-nowrap">{monthLabel}</span>}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="flex gap-[2px]">
+              <div className="flex w-6 shrink-0 flex-col text-[9px] text-text-tertiary" style={{ gap: "2px" }}>
+                <div className="h-[10px]" />
+                <div className="flex h-[10px] items-center">Mon</div>
+                <div className="h-[10px]" />
+                <div className="flex h-[10px] items-center">Wed</div>
+                <div className="h-[10px]" />
+                <div className="flex h-[10px] items-center">Fri</div>
+                <div className="h-[10px]" />
+              </div>
+              <div className="flex" style={{ gap: "2px" }}>
+                {contributions.weeks.map((week, weekIndex) => (
+                  <motion.div
+                    key={weekIndex}
+                    initial={{ opacity: 0, scale: 0.5 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    transition={{
+                      duration: 0.3,
+                      delay: delay + 0.3 + weekIndex * 0.005,
+                      ease: "easeOut",
+                    }}
+                    className="flex flex-col"
+                    style={{ gap: "2px" }}
+                  >
+                    {week.contributionDays.map((day, dayIndex) => (
+                      <div
+                        key={dayIndex}
+                        className="group/cell relative"
+                        onMouseEnter={(e) => {
+                          const rect = e.currentTarget.getBoundingClientRect();
+                          setTooltip({ day, x: rect.left + rect.width / 2, y: rect.top });
+                        }}
+                        onMouseLeave={() => setTooltip(null)}
+                      >
+                        <div className={`h-[10px] w-[10px] rounded-[2px] transition-colors duration-150 ${levelColors[day.contributionLevel]} ${levelColorsHover[day.contributionLevel]}`} />
+                      </div>
+                    ))}
+                  </motion.div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="hidden md:block">
+          <div className="mb-1 flex text-[10px] text-text-tertiary" style={{ paddingLeft: "28px" }}>
+            <div className="flex flex-1 justify-between">
+              {monthLabels.map((month, i) => (
+                <span key={i}>{month.label}</span>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex gap-[3px]">
+            <div className="flex w-6 shrink-0 flex-col justify-between py-[2px] text-[9px] text-text-tertiary">
+              <span></span>
+              <span>Mon</span>
+              <span></span>
+              <span>Wed</span>
+              <span></span>
+              <span>Fri</span>
+              <span></span>
+            </div>
+            <div className="grid flex-1" style={{ gridTemplateColumns: `repeat(${contributions.weeks.length}, 1fr)`, gap: "3px" }}>
+              {contributions.weeks.map((week, weekIndex) => (
+                <motion.div
+                  key={weekIndex}
+                  initial={{ opacity: 0, scale: 0.5 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  transition={{
+                    duration: 0.3,
+                    delay: delay + 0.3 + weekIndex * 0.005,
+                    ease: "easeOut",
+                  }}
+                  className="flex flex-col gap-[3px]"
+                >
+                  {week.contributionDays.map((day, dayIndex) => (
+                    <div
+                      key={dayIndex}
+                      className="group/cell relative aspect-square"
+                      onMouseEnter={(e) => {
+                        const rect = e.currentTarget.getBoundingClientRect();
+                        setTooltip({ day, x: rect.left + rect.width / 2, y: rect.top });
+                      }}
+                      onMouseLeave={() => setTooltip(null)}
+                    >
+                      <div className={`h-full w-full rounded-sm transition-colors duration-150 lg:rounded ${levelColors[day.contributionLevel]} ${levelColorsHover[day.contributionLevel]}`} />
+                    </div>
+                  ))}
+                </motion.div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="relative z-20 mt-3 flex items-center justify-center gap-1 text-[10px] text-text-tertiary md:justify-end">
+        <span>Less</span>
+        {(["NONE", "FIRST_QUARTILE", "SECOND_QUARTILE", "THIRD_QUARTILE", "FOURTH_QUARTILE"] as const).map((level) => (
+          <div key={level} className={`h-[10px] w-[10px] rounded-[2px] ${levelColors[level]}`} />
+        ))}
+        <span>More</span>
+      </div>
+
+      {tooltip && (
+        <div
+          className="pointer-events-none fixed z-50 -translate-x-1/2 -translate-y-full rounded-lg bg-gray-900 px-3 py-2 text-xs text-white shadow-lg"
+          style={{ left: tooltip.x, top: tooltip.y - 8 }}
+        >
+          <div className="font-medium">
+            {tooltip.day.contributionCount} contribution{tooltip.day.contributionCount !== 1 ? "s" : ""}
           </div>
           <div className="text-gray-400">{formatDate(tooltip.day.date)}</div>
           <div className="absolute left-1/2 top-full -translate-x-1/2 border-4 border-transparent border-t-gray-900" />

--- a/app/components/stats/DaysSinceRevamp.tsx
+++ b/app/components/stats/DaysSinceRevamp.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "framer-motion";
 import { useEffect, useState } from "react";
+import { usePerformanceMode } from "@/app/hooks/usePerformanceMode";
 
 interface DaysSinceRevampProps {
   revampDate: Date;
@@ -12,6 +13,7 @@ export function DaysSinceRevamp({
   revampDate,
   delay = 0,
 }: DaysSinceRevampProps) {
+  const { shouldReduceAnimations } = usePerformanceMode();
   const [isHovered, setIsHovered] = useState(false);
   const [days, setDays] = useState(0);
   const [displayDays, setDisplayDays] = useState(0);
@@ -25,6 +27,11 @@ export function DaysSinceRevamp({
 
   useEffect(() => {
     if (days === 0) return;
+
+    if (shouldReduceAnimations) {
+      setDisplayDays(days);
+      return;
+    }
 
     const duration = 1500;
     const startTime = performance.now();
@@ -48,14 +55,57 @@ export function DaysSinceRevamp({
     };
 
     requestAnimationFrame(animateCount);
-  }, [days, delay]);
+  }, [days, delay, shouldReduceAnimations]);
 
+  const cardClassName = "group relative flex h-full flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary p-6 transition-all duration-300 hover:border-indigo-400 hover:bg-white";
+
+  // Mobile: Plain div (zero animation overhead)
+  if (shouldReduceAnimations) {
+    return (
+      <div className={cardClassName}>
+        {/* Hover gradient overlay */}
+        <div className="pointer-events-none absolute inset-0 z-10 rounded-2xl bg-gradient-to-tl from-indigo-400/20 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+
+        {/* Decorative calendar */}
+        <div
+          className="absolute -bottom-2 -right-2 text-[100px] leading-none opacity-10"
+          style={{ transform: "rotate(-5deg)" }}
+        >
+          📅
+        </div>
+
+        <div className="relative z-20 flex h-full flex-col">
+          <h2 className="mb-2 font-medium text-text-primary">Site Age</h2>
+          <p className="text-sm text-text-secondary">Since last revamp</p>
+
+          <div className="mt-auto">
+            <div className="flex items-baseline gap-2">
+              <span className="text-5xl font-bold tracking-tight text-purple-primary">
+                {displayDays}
+              </span>
+              <span className="text-lg text-text-secondary">days</span>
+            </div>
+            <p className="mt-2 text-xs text-text-tertiary">
+              Launched{" "}
+              {revampDate.toLocaleDateString("en-US", {
+                month: "short",
+                day: "numeric",
+                year: "numeric",
+              })}
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Desktop: Full Framer Motion animations
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5, delay, ease: "easeOut" }}
-      className="group relative flex h-full flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary p-6 transition-all duration-300 hover:border-indigo-400 hover:bg-white"
+      className={cardClassName}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >

--- a/app/components/stats/GitHubStatsCard.tsx
+++ b/app/components/stats/GitHubStatsCard.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "framer-motion";
 import { useEffect, useState } from "react";
+import { usePerformanceMode } from "@/app/hooks/usePerformanceMode";
 
 type GitHubStatType = "stars" | "forks" | "commits";
 
@@ -108,12 +109,18 @@ export function GitHubStatsCard({
   value,
   delay = 0,
 }: GitHubStatsCardProps) {
+  const { shouldReduceAnimations } = usePerformanceMode();
   const [isHovered, setIsHovered] = useState(false);
   const [displayValue, setDisplayValue] = useState(0);
 
   const theme = themeConfig[type];
 
   useEffect(() => {
+    if (shouldReduceAnimations) {
+      setDisplayValue(value);
+      return;
+    }
+
     const duration = 1500;
     const startTime = performance.now();
     const startDelay = delay * 1000;
@@ -136,14 +143,86 @@ export function GitHubStatsCard({
     };
 
     requestAnimationFrame(animateCount);
-  }, [value, delay]);
+  }, [value, delay, shouldReduceAnimations]);
 
+  const cardClassName = "group relative flex h-full flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary p-4 transition-all duration-300 hover:border-indigo-400 hover:bg-white";
+
+  // Mobile: Plain div (zero animation overhead)
+  if (shouldReduceAnimations) {
+    return (
+      <div className={cardClassName}>
+        {/* Hover gradient overlay */}
+        <div className="pointer-events-none absolute inset-0 z-10 rounded-2xl bg-gradient-to-tl from-indigo-400/20 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+
+        {/* Floating decorations based on type */}
+        <div className="pointer-events-none absolute inset-0 overflow-hidden">
+          {type === "stars" &&
+            starDecorations.map((star, i) => (
+              <div
+                key={i}
+                className={`absolute ${theme.decorColor}`}
+                style={{
+                  left: star.x,
+                  top: star.y,
+                  opacity: 0.3,
+                  transform: `rotate(${star.rotate}deg)`,
+                }}
+              >
+                <StarShape size={star.size} />
+              </div>
+            ))}
+
+          {type === "forks" &&
+            forkDecorations.map((fork, i) => (
+              <div
+                key={i}
+                className={`absolute ${theme.decorColor}`}
+                style={{
+                  left: fork.x,
+                  top: fork.y,
+                  opacity: 0.28,
+                  transform: `rotate(${fork.rotate}deg)`,
+                }}
+              >
+                <BranchShape />
+              </div>
+            ))}
+
+          {type === "commits" &&
+            commitDecorations.map((commit, i) => (
+              <div
+                key={i}
+                className={`absolute ${theme.decorColor}`}
+                style={{
+                  left: commit.x,
+                  top: commit.y,
+                  opacity: 0.32,
+                }}
+              >
+                <CommitDot />
+              </div>
+            ))}
+        </div>
+
+        {/* Content */}
+        <div className="relative z-20 flex h-full flex-col">
+          <h2 className="mb-1 text-sm font-medium text-text-primary">{label}</h2>
+
+          <p className="mt-auto text-2xl font-semibold tracking-tight text-purple-primary">
+            {displayValue.toLocaleString()}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Desktop: Full Framer Motion animations
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5, delay, ease: "easeOut" }}
-      className="group relative flex h-full flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary p-4 transition-all duration-300 hover:border-indigo-400 hover:bg-white"
+      className={cardClassName}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >

--- a/app/components/stats/LighthouseScoreCard.tsx
+++ b/app/components/stats/LighthouseScoreCard.tsx
@@ -3,6 +3,7 @@
 import { motion } from "framer-motion";
 import { useState, useEffect } from "react";
 import type { LighthouseScores } from "@/app/lib/stats/types";
+import { usePerformanceMode } from "@/app/hooks/usePerformanceMode";
 
 interface LighthouseScoreCardProps {
   scores: LighthouseScores;
@@ -15,6 +16,7 @@ interface ScoreBarProps {
   label: string;
   delay?: number;
   isHovered: boolean;
+  shouldReduceAnimations: boolean;
 }
 
 function getScoreColor(score: number) {
@@ -42,11 +44,16 @@ function getScoreColor(score: number) {
   };
 }
 
-function ScoreBar({ score, label, delay = 0, isHovered }: ScoreBarProps) {
+function ScoreBar({ score, label, delay = 0, isHovered, shouldReduceAnimations }: ScoreBarProps) {
   const [displayScore, setDisplayScore] = useState(0);
   const colors = getScoreColor(score);
 
   useEffect(() => {
+    if (shouldReduceAnimations) {
+      setDisplayScore(score);
+      return;
+    }
+
     const duration = 1200;
     const startTime = performance.now();
     const startDelay = delay * 1000;
@@ -69,8 +76,29 @@ function ScoreBar({ score, label, delay = 0, isHovered }: ScoreBarProps) {
     };
 
     requestAnimationFrame(animateScore);
-  }, [score, delay]);
+  }, [score, delay, shouldReduceAnimations]);
 
+  // Mobile: Plain div
+  if (shouldReduceAnimations) {
+    return (
+      <div className="flex flex-col gap-1.5">
+        <div className="flex items-center justify-between">
+          <span className="text-xs font-medium text-text-secondary">{label}</span>
+          <span className={`text-sm font-bold tabular-nums ${colors.text}`}>
+            {displayScore}
+          </span>
+        </div>
+        <div className={`h-2 w-full overflow-hidden rounded-full ${colors.barBg}`}>
+          <div
+            style={{ width: `${displayScore}%` }}
+            className={`h-full rounded-full ${colors.bar}`}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  // Desktop: Full animations
   return (
     <div className="flex flex-col gap-1.5">
       <div className="flex items-center justify-between">
@@ -100,10 +128,12 @@ function RadarBackground({
   scores,
   isHovered,
   delay,
+  shouldReduceAnimations,
 }: {
   scores: number[];
   isHovered: boolean;
   delay: number;
+  shouldReduceAnimations: boolean;
 }) {
   const size = 220;
   const center = size / 2;
@@ -123,6 +153,89 @@ function RadarBackground({
       .join(" ");
   };
 
+  // Mobile: Plain div with static SVG
+  if (shouldReduceAnimations) {
+    return (
+      <div className="pointer-events-none absolute -bottom-16 -right-16">
+        <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+          {/* Concentric circles */}
+          {[0.25, 0.5, 0.75, 1].map((scale, i) => (
+            <circle
+              key={i}
+              cx={center}
+              cy={center}
+              r={maxRadius * scale}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={scale === 1 ? 1.5 : 1}
+              className="text-gray-300"
+              opacity={0.25}
+            />
+          ))}
+
+          {/* Cross axes */}
+          <g opacity={0.2}>
+            <line
+              x1={center}
+              y1={center - maxRadius}
+              x2={center}
+              y2={center + maxRadius}
+              stroke="currentColor"
+              strokeWidth={1}
+              className="text-gray-300"
+            />
+            <line
+              x1={center - maxRadius}
+              y1={center}
+              x2={center + maxRadius}
+              y2={center}
+              stroke="currentColor"
+              strokeWidth={1}
+              className="text-gray-300"
+            />
+          </g>
+
+          {/* Score polygon fill */}
+          <polygon
+            points={getPolygonPoints(scores)}
+            fill="url(#radarGradient)"
+            stroke="rgba(251, 146, 60, 0.5)"
+            strokeWidth={2}
+            opacity={0.25}
+          />
+
+          {/* Score points */}
+          {scores.map((score, i) => {
+            const angles = [-90, 0, 90, 180];
+            const angle = (angles[i] * Math.PI) / 180;
+            const radius = (score / 100) * maxRadius;
+            const x = center + radius * Math.cos(angle);
+            const y = center + radius * Math.sin(angle);
+            return (
+              <circle
+                key={i}
+                cx={x}
+                cy={y}
+                r={4}
+                fill="rgb(251, 146, 60)"
+                opacity={0.5}
+              />
+            );
+          })}
+
+          {/* Gradient definition */}
+          <defs>
+            <radialGradient id="radarGradient" cx="50%" cy="50%" r="50%">
+              <stop offset="0%" stopColor="rgb(251, 191, 36)" stopOpacity="0.5" />
+              <stop offset="100%" stopColor="rgb(251, 146, 60)" stopOpacity="0.15" />
+            </radialGradient>
+          </defs>
+        </svg>
+      </div>
+    );
+  }
+
+  // Desktop: Animated radar
   return (
     <motion.div
       initial={{ opacity: 0 }}
@@ -232,7 +345,29 @@ function RadarBackground({
 }
 
 // Animated pulse rings
-function PulseRings({ isHovered }: { isHovered: boolean }) {
+function PulseRings({ isHovered, shouldReduceAnimations }: { isHovered: boolean; shouldReduceAnimations: boolean }) {
+  // Mobile: Plain div
+  if (shouldReduceAnimations) {
+    return (
+      <div className="pointer-events-none absolute -bottom-20 -right-20">
+        {[0, 1, 2].map((i) => (
+          <div
+            key={i}
+            className="absolute rounded-full border border-amber-400/30"
+            style={{
+              width: 140 + i * 50,
+              height: 140 + i * 50,
+              right: -(i * 25),
+              bottom: -(i * 25),
+              opacity: 0.08,
+            }}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  // Desktop: Animated rings
   return (
     <div className="pointer-events-none absolute -bottom-20 -right-20">
       {[0, 1, 2].map((i) => (
@@ -264,6 +399,7 @@ export function LighthouseScoreCard({
   strategy,
   delay = 0,
 }: LighthouseScoreCardProps) {
+  const { shouldReduceAnimations } = usePerformanceMode();
   const [isHovered, setIsHovered] = useState(false);
 
   const scoreItems = [
@@ -280,12 +416,91 @@ export function LighthouseScoreCard({
     scores.seo,
   ];
 
+  const cardClassName = "group relative flex h-full flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary p-5 transition-all duration-300 hover:border-indigo-400 hover:bg-white";
+
+  // Mobile: Plain div (zero animation overhead)
+  if (shouldReduceAnimations) {
+    return (
+      <div className={cardClassName}>
+        {/* Hover gradient overlay */}
+        <div className="pointer-events-none absolute inset-0 z-10 rounded-2xl bg-gradient-to-tl from-indigo-400/20 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+
+        {/* Pulse rings background */}
+        <PulseRings isHovered={false} shouldReduceAnimations={shouldReduceAnimations} />
+
+        {/* Radar visualization */}
+        <RadarBackground
+          scores={scoreValues}
+          isHovered={false}
+          delay={delay}
+          shouldReduceAnimations={shouldReduceAnimations}
+        />
+
+        {/* Header */}
+        <div className="relative z-20 mb-4 flex items-center gap-2.5">
+          <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-amber-100 to-orange-100">
+            {strategy === "mobile" ? (
+              <svg
+                className="h-4 w-4 text-amber-600"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"
+                />
+              </svg>
+            ) : (
+              <svg
+                className="h-4 w-4 text-amber-600"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                />
+              </svg>
+            )}
+          </div>
+          <div>
+            <h2 className="text-sm font-semibold text-text-primary">
+              {strategy === "mobile" ? "Mobile" : "Desktop"}
+            </h2>
+            <p className="text-[10px] text-text-tertiary">Lighthouse</p>
+          </div>
+        </div>
+
+        {/* Score bars in 2x2 grid */}
+        <div className="relative z-20 grid flex-1 grid-cols-2 gap-x-4 gap-y-3">
+          {scoreItems.map((item, i) => (
+            <ScoreBar
+              key={item.label}
+              score={item.score}
+              label={item.label}
+              delay={delay + 0.15 + i * 0.08}
+              isHovered={false}
+              shouldReduceAnimations={shouldReduceAnimations}
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // Desktop: Full Framer Motion animations
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5, delay, ease: "easeOut" }}
-      className="group relative flex h-full flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary p-5 transition-all duration-300 hover:border-indigo-400 hover:bg-white"
+      className={cardClassName}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
@@ -293,13 +508,14 @@ export function LighthouseScoreCard({
       <div className="pointer-events-none absolute inset-0 z-10 rounded-2xl bg-gradient-to-tl from-indigo-400/20 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
 
       {/* Pulse rings background */}
-      <PulseRings isHovered={isHovered} />
+      <PulseRings isHovered={isHovered} shouldReduceAnimations={shouldReduceAnimations} />
 
       {/* Radar visualization */}
       <RadarBackground
         scores={scoreValues}
         isHovered={isHovered}
         delay={delay}
+        shouldReduceAnimations={shouldReduceAnimations}
       />
 
       {/* Header */}
@@ -362,6 +578,7 @@ export function LighthouseScoreCard({
             label={item.label}
             delay={delay + 0.15 + i * 0.08}
             isHovered={isHovered}
+            shouldReduceAnimations={shouldReduceAnimations}
           />
         ))}
       </div>

--- a/app/components/stats/MostViewedArticleCard.tsx
+++ b/app/components/stats/MostViewedArticleCard.tsx
@@ -4,6 +4,7 @@ import { motion } from "framer-motion";
 import Link from "next/link";
 import Image from "next/image";
 import { useState, useEffect } from "react";
+import { usePerformanceMode } from "@/app/hooks/usePerformanceMode";
 
 interface MostViewedArticleCardProps {
   title: string;
@@ -20,10 +21,16 @@ export function MostViewedArticleCard({
   viewCount,
   delay = 0,
 }: MostViewedArticleCardProps) {
+  const { shouldReduceAnimations } = usePerformanceMode();
   const [isHovered, setIsHovered] = useState(false);
   const [displayCount, setDisplayCount] = useState(0);
 
   useEffect(() => {
+    if (shouldReduceAnimations) {
+      setDisplayCount(viewCount);
+      return;
+    }
+
     const duration = 1500;
     const startTime = performance.now();
     const startDelay = delay * 1000;
@@ -46,15 +53,143 @@ export function MostViewedArticleCard({
     };
 
     requestAnimationFrame(animateCount);
-  }, [viewCount, delay]);
+  }, [viewCount, delay, shouldReduceAnimations]);
 
+  const cardClassName = "group relative flex h-full min-h-[420px] flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary transition-all duration-300 hover:border-indigo-400 hover:bg-white";
+
+  // Mobile: Plain div (zero animation overhead)
+  if (shouldReduceAnimations) {
+    return (
+      <Link href={`/blog/${slug}`} className="block h-full">
+        <div className={cardClassName}>
+          {/* Hover gradient overlay */}
+          <div className="pointer-events-none absolute inset-0 z-30 rounded-2xl bg-gradient-to-tl from-indigo-400/20 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+
+          {/* Large article preview graphic */}
+          <div className="relative h-[280px] flex-shrink-0">
+            {/* Paper shadow behind */}
+            <div
+              style={{
+                transform: "translate(-5px, 5px) rotate(-3deg)",
+              }}
+              className="absolute inset-4 rounded-lg bg-border-primary/40"
+            />
+
+            {/* Main paper/article card */}
+            <div
+              style={{
+                transform: "rotate(1.5deg)",
+              }}
+              className="absolute inset-4 flex flex-col overflow-hidden rounded-lg border border-border-primary bg-white shadow-sm"
+            >
+              {/* Mini article header bar */}
+              <div className="flex flex-shrink-0 items-center gap-1.5 border-b border-border-primary/50 bg-slate-50 px-3 py-2">
+                <div className="h-2 w-2 rounded-full bg-red-300" />
+                <div className="h-2 w-2 rounded-full bg-yellow-300" />
+                <div className="h-2 w-2 rounded-full bg-green-300" />
+                <div className="ml-2 h-2 flex-1 rounded bg-border-primary/30" />
+              </div>
+
+              {/* Banner image with title overlay - like actual article page */}
+              <div className="relative h-[100px] w-full flex-shrink-0 overflow-hidden">
+                <Image
+                  src={`/blog/${imageName}`}
+                  alt={title}
+                  fill
+                  className="object-cover object-top"
+                />
+                {/* Gradient overlay for title readability */}
+                <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent" />
+                {/* Article title on banner */}
+                <div className="absolute inset-x-0 bottom-0 p-2">
+                  <p className="line-clamp-2 text-[8px] font-bold leading-tight text-white">
+                    {title}
+                  </p>
+                </div>
+              </div>
+
+              {/* Article content preview - mimics actual article text */}
+              <div className="flex-1 space-y-2 overflow-hidden bg-[#F7F7F8] p-2.5">
+                {/* First paragraph */}
+                <div className="space-y-1">
+                  <div className="h-[5px] w-full rounded-sm bg-text-secondary/25" />
+                  <div className="h-[5px] w-full rounded-sm bg-text-secondary/25" />
+                  <div className="h-[5px] w-[92%] rounded-sm bg-text-secondary/25" />
+                  <div className="h-[5px] w-[85%] rounded-sm bg-text-secondary/25" />
+                </div>
+                {/* Second paragraph */}
+                <div className="space-y-1">
+                  <div className="h-[5px] w-full rounded-sm bg-text-secondary/20" />
+                  <div className="h-[5px] w-full rounded-sm bg-text-secondary/20" />
+                  <div className="h-[5px] w-[78%] rounded-sm bg-text-secondary/20" />
+                </div>
+                {/* Code block hint */}
+                <div className="rounded bg-slate-200/60 p-1.5">
+                  <div className="space-y-1">
+                    <div className="h-[4px] w-[60%] rounded-sm bg-slate-400/30" />
+                    <div className="h-[4px] w-[75%] rounded-sm bg-slate-400/30" />
+                    <div className="h-[4px] w-[45%] rounded-sm bg-slate-400/30" />
+                  </div>
+                </div>
+                {/* Third paragraph */}
+                <div className="space-y-1">
+                  <div className="h-[5px] w-full rounded-sm bg-text-secondary/15" />
+                  <div className="h-[5px] w-[88%] rounded-sm bg-text-secondary/15" />
+                </div>
+              </div>
+            </div>
+
+            {/* Fade to white at bottom for text visibility */}
+            <div className="pointer-events-none absolute inset-x-0 bottom-0 z-20 h-32 bg-gradient-to-t from-bg-primary via-bg-primary/80 to-transparent transition-colors group-hover:from-white group-hover:via-white/80" />
+          </div>
+
+          {/* Content overlay at bottom */}
+          <div className="relative z-20 px-6 pb-6">
+            <h2 className="mb-1 font-medium text-text-primary">
+              Most Viewed Article
+            </h2>
+            <h3 className="mb-3 line-clamp-2 text-sm leading-snug text-text-secondary transition-colors group-hover:text-text-primary">
+              {title}
+            </h3>
+
+            {/* View count */}
+            <div className="flex items-baseline gap-2">
+              <span className="text-3xl font-bold tabular-nums tracking-tight text-purple-primary">
+                {displayCount.toLocaleString()}
+              </span>
+              <span className="text-sm text-text-tertiary">views</span>
+            </div>
+          </div>
+
+          {/* Link arrow */}
+          <div className="absolute bottom-4 right-4 z-40 flex h-8 w-8 items-center justify-center rounded-full bg-indigo-100 opacity-0 transition-opacity group-hover:opacity-100">
+            <svg
+              className="h-4 w-4 text-indigo-600"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M7 17L17 7M17 7H7M17 7V17"
+              />
+            </svg>
+          </div>
+        </div>
+      </Link>
+    );
+  }
+
+  // Desktop: Full Framer Motion animations
   return (
     <Link href={`/blog/${slug}`} className="block h-full">
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5, delay, ease: "easeOut" }}
-        className="group relative flex h-full min-h-[420px] flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary transition-all duration-300 hover:border-indigo-400 hover:bg-white"
+        className={cardClassName}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
       >

--- a/app/components/stats/MostViewedArticleCard.tsx
+++ b/app/components/stats/MostViewedArticleCard.tsx
@@ -55,6 +55,9 @@ export function MostViewedArticleCard({
     requestAnimationFrame(animateCount);
   }, [viewCount, delay, shouldReduceAnimations]);
 
+  // Use actual value immediately if animations are reduced to prevent flash from 0
+  const effectiveDisplayCount = shouldReduceAnimations ? viewCount : displayCount;
+
   const cardClassName = "group relative flex h-full min-h-[420px] flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary transition-all duration-300 hover:border-indigo-400 hover:bg-white";
 
   // Mobile: Plain div (zero animation overhead)
@@ -155,7 +158,7 @@ export function MostViewedArticleCard({
             {/* View count */}
             <div className="flex items-baseline gap-2">
               <span className="text-3xl font-bold tabular-nums tracking-tight text-purple-primary">
-                {displayCount.toLocaleString()}
+                {effectiveDisplayCount.toLocaleString()}
               </span>
               <span className="text-sm text-text-tertiary">views</span>
             </div>
@@ -295,7 +298,7 @@ export function MostViewedArticleCard({
               transition={{ type: "spring", stiffness: 300, damping: 20 }}
               className="text-3xl font-bold tabular-nums tracking-tight text-purple-primary"
             >
-              {displayCount.toLocaleString()}
+              {effectiveDisplayCount.toLocaleString()}
             </motion.span>
             <span className="text-sm text-text-tertiary">views</span>
           </div>

--- a/app/components/stats/ReactionBreakdown.tsx
+++ b/app/components/stats/ReactionBreakdown.tsx
@@ -3,198 +3,102 @@
 import { motion } from "framer-motion";
 import { useState } from "react";
 import type { ReactionType } from "@/app/lib/stats/types";
+import { usePerformanceMode } from "@/app/hooks/usePerformanceMode";
 
 interface ReactionBreakdownProps {
   reactions: Record<ReactionType, number>;
   delay?: number;
 }
 
-// SVG Icons from ArticleReactions component
-const LikeSVG = ({ isHovered }: { isHovered: boolean }) => (
-  <svg
-    width="28"
-    height="28"
-    viewBox="0 0 24 24"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <motion.g
-      animate={{
-        rotate: isHovered ? [0, -15, 20, 0] : 0,
-      }}
-      transition={{
-        rotate: {
-          duration: 0.6,
-          ease: "easeInOut",
-          times: [0, 0.3, 0.6, 1],
-        },
-      }}
-      style={{ transformOrigin: "center" }}
-    >
-      <path
-        d="M12.25 9.75001H11.5C11.5 10.1642 11.8358 10.5 12.25 10.5V9.75001ZM18 9.75001L18 9.00001H18V9.75001ZM12.25 6.897L11.5 6.897V6.897H12.25ZM9.77107 5.59894L9.02168 5.56871L9.02168 5.56871L9.77107 5.59894ZM7.25 9.75001L7.25 9.00001C7.05109 9.00001 6.86032 9.07903 6.71967 9.21968C6.57902 9.36033 6.5 9.5511 6.5 9.75001L7.25 9.75001ZM18 12.25L18 11.5H18V12.25ZM16.75 11.5C16.3358 11.5 16 11.8358 16 12.25C16 12.6642 16.3358 13 16.75 13V11.5ZM17.2658 17.5267L16.523 17.4234L17.2658 17.5267ZM15.0809 19.2407L15.0044 19.9868L15.0044 19.9868L15.0809 19.2407ZM8.14797 18.5296L8.22449 17.7835L8.22449 17.7835L8.14797 18.5296ZM7.25 17.5348L8 17.5348L7.25 17.5348ZM10.9795 4.84133L10.6441 5.51215L10.6441 5.51215L10.9795 4.84133ZM12.25 10.5H18V9.00001H12.25V10.5ZM13 9.75001V6.897H11.5V9.75001H13ZM9.02168 5.56871C8.98986 6.35737 8.87029 7.28162 8.55917 7.98426C8.25916 8.66183 7.85682 9.00001 7.25 9.00001L7.25 10.5C8.66762 10.5 9.49282 9.58057 9.93074 8.59156C10.3575 7.62762 10.4863 6.47634 10.5205 5.62917L9.02168 5.56871ZM18 11.5H16.75V13H18V11.5ZM17.2572 12.1467L16.523 17.4234L18.0087 17.6301L18.7428 12.3534L17.2572 12.1467ZM15.1574 18.4946L8.22449 17.7835L8.07145 19.2757L15.0044 19.9868L15.1574 18.4946ZM8 17.5348L8 9.75001L6.5 9.75001L6.5 17.5348L8 17.5348ZM8.22449 17.7835C8.09697 17.7704 8 17.663 8 17.5348L6.5 17.5348C6.5 18.4322 7.17877 19.1841 8.07145 19.2757L8.22449 17.7835ZM18.5 11C18.5 11.2762 18.2761 11.5 18 11.5L18 13C19.1046 13 20 12.1046 20 11L18.5 11ZM16.523 17.4234C16.4303 18.0898 15.8267 18.5632 15.1574 18.4946L15.0044 19.9868C16.4769 20.1378 17.8047 19.0962 18.0087 17.6301L16.523 17.4234ZM11.3149 4.17051C10.2352 3.63063 9.06523 4.48919 9.02168 5.56871L10.5205 5.62917C10.5217 5.59822 10.5406 5.5562 10.5864 5.52693C10.6071 5.51378 10.6234 5.51013 10.6311 5.50947C10.6361 5.50905 10.6385 5.50932 10.6441 5.51215L11.3149 4.17051ZM13 6.897C13 5.74239 12.3477 4.68687 11.3149 4.17051L10.6441 5.51215C11.1687 5.77443 11.5 6.31055 11.5 6.897L13 6.897ZM18 10.5C18.2761 10.5 18.5 10.7239 18.5 11L20 11C20 9.89544 19.1046 9.00001 18 9.00001L18 10.5Z"
-        fill={isHovered ? "#3b82f6" : "#64748b"}
-        className="transition-colors duration-200"
-      />
-      <path
-        d="M5.75 9.5H6.25V8H5.75V9.5ZM6.5 9.75V18.25H8V9.75H6.5ZM6.25 18.5H5.75V20H6.25V18.5ZM5.5 18.25V9.75H4V18.25H5.5ZM5.75 18.5C5.61193 18.5 5.5 18.3881 5.5 18.25H4C4 19.2165 4.7835 20 5.75 20V18.5ZM6.5 18.25C6.5 18.3881 6.38807 18.5 6.25 18.5V20C7.2165 20 8 19.2165 8 18.25H6.5ZM6.25 9.5C6.38807 9.5 6.5 9.61193 6.5 9.75H8C8 8.7835 7.2165 8 6.25 8V9.5ZM5.75 8C4.7835 8 4 8.7835 4 9.75H5.5C5.5 9.61193 5.61193 9.5 5.75 9.5V8Z"
-        fill={isHovered ? "#3b82f6" : "#64748b"}
-        className="transition-colors duration-200"
-      />
-    </motion.g>
-  </svg>
-);
+// SVG Icons - Mobile (static) and Desktop (animated) versions
+const LikeSVG = ({ isHovered, shouldReduceAnimations }: { isHovered: boolean; shouldReduceAnimations: boolean }) => {
+  if (shouldReduceAnimations) {
+    return (
+      <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <g>
+          <path d="M12.25 9.75001H11.5C11.5 10.1642 11.8358 10.5 12.25 10.5V9.75001ZM18 9.75001L18 9.00001H18V9.75001ZM12.25 6.897L11.5 6.897V6.897H12.25ZM9.77107 5.59894L9.02168 5.56871L9.02168 5.56871L9.77107 5.59894ZM7.25 9.75001L7.25 9.00001C7.05109 9.00001 6.86032 9.07903 6.71967 9.21968C6.57902 9.36033 6.5 9.5511 6.5 9.75001L7.25 9.75001ZM18 12.25L18 11.5H18V12.25ZM16.75 11.5C16.3358 11.5 16 11.8358 16 12.25C16 12.6642 16.3358 13 16.75 13V11.5ZM17.2658 17.5267L16.523 17.4234L17.2658 17.5267ZM15.0809 19.2407L15.0044 19.9868L15.0044 19.9868L15.0809 19.2407ZM8.14797 18.5296L8.22449 17.7835L8.22449 17.7835L8.14797 18.5296ZM7.25 17.5348L8 17.5348L7.25 17.5348ZM10.9795 4.84133L10.6441 5.51215L10.6441 5.51215L10.9795 4.84133ZM12.25 10.5H18V9.00001H12.25V10.5ZM13 9.75001V6.897H11.5V9.75001H13ZM9.02168 5.56871C8.98986 6.35737 8.87029 7.28162 8.55917 7.98426C8.25916 8.66183 7.85682 9.00001 7.25 9.00001L7.25 10.5C8.66762 10.5 9.49282 9.58057 9.93074 8.59156C10.3575 7.62762 10.4863 6.47634 10.5205 5.62917L9.02168 5.56871ZM18 11.5H16.75V13H18V11.5ZM17.2572 12.1467L16.523 17.4234L18.0087 17.6301L18.7428 12.3534L17.2572 12.1467ZM15.1574 18.4946L8.22449 17.7835L8.07145 19.2757L15.0044 19.9868L15.1574 18.4946ZM8 17.5348L8 9.75001L6.5 9.75001L6.5 17.5348L8 17.5348ZM8.22449 17.7835C8.09697 17.7704 8 17.663 8 17.5348L6.5 17.5348C6.5 18.4322 7.17877 19.1841 8.07145 19.2757L8.22449 17.7835ZM18.5 11C18.5 11.2762 18.2761 11.5 18 11.5L18 13C19.1046 13 20 12.1046 20 11L18.5 11ZM16.523 17.4234C16.4303 18.0898 15.8267 18.5632 15.1574 18.4946L15.0044 19.9868C16.4769 20.1378 17.8047 19.0962 18.0087 17.6301L16.523 17.4234ZM11.3149 4.17051C10.2352 3.63063 9.06523 4.48919 9.02168 5.56871L10.5205 5.62917C10.5217 5.59822 10.5406 5.5562 10.5864 5.52693C10.6071 5.51378 10.6234 5.51013 10.6311 5.50947C10.6361 5.50905 10.6385 5.50932 10.6441 5.51215L11.3149 4.17051ZM13 6.897C13 5.74239 12.3477 4.68687 11.3149 4.17051L10.6441 5.51215C11.1687 5.77443 11.5 6.31055 11.5 6.897L13 6.897ZM18 10.5C18.2761 10.5 18.5 10.7239 18.5 11L20 11C20 9.89544 19.1046 9.00001 18 9.00001L18 10.5Z" fill="#64748b" />
+          <path d="M5.75 9.5H6.25V8H5.75V9.5ZM6.5 9.75V18.25H8V9.75H6.5ZM6.25 18.5H5.75V20H6.25V18.5ZM5.5 18.25V9.75H4V18.25H5.5ZM5.75 18.5C5.61193 18.5 5.5 18.3881 5.5 18.25H4C4 19.2165 4.7835 20 5.75 20V18.5ZM6.5 18.25C6.5 18.3881 6.38807 18.5 6.25 18.5V20C7.2165 20 8 19.2165 8 18.25H6.5ZM6.25 9.5C6.38807 9.5 6.5 9.61193 6.5 9.75H8C8 8.7835 7.2165 8 6.25 8V9.5ZM5.75 8C4.7835 8 4 8.7835 4 9.75H5.5C5.5 9.61193 5.61193 9.5 5.75 9.5V8Z" fill="#64748b" />
+        </g>
+      </svg>
+    );
+  }
 
-const HeartSVG = ({ isHovered }: { isHovered: boolean }) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="28"
-    height="28"
-    fill="none"
-    viewBox="0 0 24 24"
-  >
-    <motion.path
-      d="M9.497 10.877c-.95-1.233-2.534-1.565-3.724-.436-1.19 1.13-1.357 3.019-.423 4.355l4.147 4.454 4.146-4.454c.934-1.336.787-3.237-.423-4.355-1.21-1.117-2.774-.797-3.723.436Z"
-      animate={{
-        fill: isHovered ? "#fda4af" : "transparent",
-        stroke: isHovered ? "#e11d48" : "#64748b",
-      }}
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      transition={{ duration: 0.2 }}
-    />
-    <motion.path
-      d="M16.998 5.284c-.45-.584-1.2-.742-1.763-.207a1.606 1.606 0 0 0-.2 2.063l1.963 2.11 1.964-2.11c.443-.633.373-1.533-.2-2.063-.573-.529-1.314-.377-1.764.207Z"
-      animate={{
-        fill: isHovered ? "#fda4af" : "transparent",
-        stroke: isHovered ? "#e11d48" : "#64748b",
-        opacity: isHovered ? 1 : 0,
-        scale: isHovered ? 1 : 0.5,
-      }}
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      transition={{ duration: 0.3 }}
-    />
-  </svg>
-);
+  return (
+    <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <motion.g animate={{ rotate: isHovered ? [0, -15, 20, 0] : 0 }} transition={{ rotate: { duration: 0.6, ease: "easeInOut", times: [0, 0.3, 0.6, 1] } }} style={{ transformOrigin: "center" }}>
+        <path d="M12.25 9.75001H11.5C11.5 10.1642 11.8358 10.5 12.25 10.5V9.75001ZM18 9.75001L18 9.00001H18V9.75001ZM12.25 6.897L11.5 6.897V6.897H12.25ZM9.77107 5.59894L9.02168 5.56871L9.02168 5.56871L9.77107 5.59894ZM7.25 9.75001L7.25 9.00001C7.05109 9.00001 6.86032 9.07903 6.71967 9.21968C6.57902 9.36033 6.5 9.5511 6.5 9.75001L7.25 9.75001ZM18 12.25L18 11.5H18V12.25ZM16.75 11.5C16.3358 11.5 16 11.8358 16 12.25C16 12.6642 16.3358 13 16.75 13V11.5ZM17.2658 17.5267L16.523 17.4234L17.2658 17.5267ZM15.0809 19.2407L15.0044 19.9868L15.0044 19.9868L15.0809 19.2407ZM8.14797 18.5296L8.22449 17.7835L8.22449 17.7835L8.14797 18.5296ZM7.25 17.5348L8 17.5348L7.25 17.5348ZM10.9795 4.84133L10.6441 5.51215L10.6441 5.51215L10.9795 4.84133ZM12.25 10.5H18V9.00001H12.25V10.5ZM13 9.75001V6.897H11.5V9.75001H13ZM9.02168 5.56871C8.98986 6.35737 8.87029 7.28162 8.55917 7.98426C8.25916 8.66183 7.85682 9.00001 7.25 9.00001L7.25 10.5C8.66762 10.5 9.49282 9.58057 9.93074 8.59156C10.3575 7.62762 10.4863 6.47634 10.5205 5.62917L9.02168 5.56871ZM18 11.5H16.75V13H18V11.5ZM17.2572 12.1467L16.523 17.4234L18.0087 17.6301L18.7428 12.3534L17.2572 12.1467ZM15.1574 18.4946L8.22449 17.7835L8.07145 19.2757L15.0044 19.9868L15.1574 18.4946ZM8 17.5348L8 9.75001L6.5 9.75001L6.5 17.5348L8 17.5348ZM8.22449 17.7835C8.09697 17.7704 8 17.663 8 17.5348L6.5 17.5348C6.5 18.4322 7.17877 19.1841 8.07145 19.2757L8.22449 17.7835ZM18.5 11C18.5 11.2762 18.2761 11.5 18 11.5L18 13C19.1046 13 20 12.1046 20 11L18.5 11ZM16.523 17.4234C16.4303 18.0898 15.8267 18.5632 15.1574 18.4946L15.0044 19.9868C16.4769 20.1378 17.8047 19.0962 18.0087 17.6301L16.523 17.4234ZM11.3149 4.17051C10.2352 3.63063 9.06523 4.48919 9.02168 5.56871L10.5205 5.62917C10.5217 5.59822 10.5406 5.5562 10.5864 5.52693C10.6071 5.51378 10.6234 5.51013 10.6311 5.50947C10.6361 5.50905 10.6385 5.50932 10.6441 5.51215L11.3149 4.17051ZM13 6.897C13 5.74239 12.3477 4.68687 11.3149 4.17051L10.6441 5.51215C11.1687 5.77443 11.5 6.31055 11.5 6.897L13 6.897ZM18 10.5C18.2761 10.5 18.5 10.7239 18.5 11L20 11C20 9.89544 19.1046 9.00001 18 9.00001L18 10.5Z" fill={isHovered ? "#3b82f6" : "#64748b"} className="transition-colors duration-200" />
+        <path d="M5.75 9.5H6.25V8H5.75V9.5ZM6.5 9.75V18.25H8V9.75H6.5ZM6.25 18.5H5.75V20H6.25V18.5ZM5.5 18.25V9.75H4V18.25H5.5ZM5.75 18.5C5.61193 18.5 5.5 18.3881 5.5 18.25H4C4 19.2165 4.7835 20 5.75 20V18.5ZM6.5 18.25C6.5 18.3881 6.38807 18.5 6.25 18.5V20C7.2165 20 8 19.2165 8 18.25H6.5ZM6.25 9.5C6.38807 9.5 6.5 9.61193 6.5 9.75H8C8 8.7835 7.2165 8 6.25 8V9.5ZM5.75 8C4.7835 8 4 8.7835 4 9.75H5.5C5.5 9.61193 5.61193 9.5 5.75 9.5V8Z" fill={isHovered ? "#3b82f6" : "#64748b"} className="transition-colors duration-200" />
+      </motion.g>
+    </svg>
+  );
+};
 
-const CelebrateSVG = ({ isHovered }: { isHovered: boolean }) => (
-  <svg
-    width="28"
-    height="28"
-    viewBox="0 0 24 24"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      d="M8.89062 9.28125L4.87279 17.7937C4.44606 18.628 5.29889 19.5379 6.16008 19.1671L14.6016 16.1875"
-      stroke={isHovered ? "#4f46e5" : "#64748b"}
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      fill={isHovered ? "#c7d2fe" : "transparent"}
-      className="transition-all duration-200"
-    />
-    <path
-      d="M13.3196 10.9774C14.9594 12.8695 15.698 15.085 14.9691 15.9259C14.2403 16.7669 12.3202 15.9147 10.6804 14.0226C9.04057 12.1305 8.30205 9.91499 9.03085 9.07406C9.75966 8.23313 11.6798 9.08527 13.3196 10.9774Z"
-      stroke={isHovered ? "#4f46e5" : "#64748b"}
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      fill={isHovered ? "#c7d2fe" : "transparent"}
-      className="transition-all duration-200"
-    />
-    <motion.path
-      d="M11.5 5C11.5 5.27614 11.2761 5.5 11 5.5C10.7239 5.5 10.5 5.27614 10.5 5C10.5 4.72386 10.7239 4.5 11 4.5C11.2761 4.5 11.5 4.72386 11.5 5Z"
-      stroke={isHovered ? "#4f46e5" : "#64748b"}
-      fill={isHovered ? "#eab308" : "transparent"}
-      animate={{ opacity: isHovered ? 1 : 0.3 }}
-    />
-    <motion.path
-      d="M15.75 9.25L15.8787 9.12132C17.0503 7.94975 17.0503 6.05025 15.8787 4.87868L15.75 4.75"
-      stroke={isHovered ? "#6366f1" : "#64748b"}
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      animate={{ opacity: isHovered ? 1 : 0 }}
-    />
-    <motion.path
-      d="M17 13.0001L17.2929 12.7072C17.6834 12.3167 18.3166 12.3167 18.7071 12.7072L19 13.0001"
-      stroke={isHovered ? "#4f46e5" : "#64748b"}
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      animate={{ opacity: isHovered ? 1 : 0 }}
-    />
-  </svg>
-);
+const HeartSVG = ({ isHovered, shouldReduceAnimations }: { isHovered: boolean; shouldReduceAnimations: boolean }) => {
+  if (shouldReduceAnimations) {
+    return (
+      <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="none" viewBox="0 0 24 24">
+        <path d="M9.497 10.877c-.95-1.233-2.534-1.565-3.724-.436-1.19 1.13-1.357 3.019-.423 4.355l4.147 4.454 4.146-4.454c.934-1.336.787-3.237-.423-4.355-1.21-1.117-2.774-.797-3.723.436Z" fill="transparent" stroke="#64748b" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    );
+  }
 
-const InsightfulSVG = ({ isHovered }: { isHovered: boolean }) => (
-  <svg
-    width="28"
-    height="28"
-    viewBox="0 0 24 24"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <motion.path
-      d="M12 4.75C8.5 4.75 6.75 7.5 6.75 10C6.75 14 9.75 14.5 9.75 16V18.2505C9.75 18.8028 10.1977 19.25 10.75 19.25H13.25C13.8023 19.25 14.25 18.8028 14.25 18.2505V16C14.25 14.5 17.25 14 17.25 10C17.25 7.5 15.5 4.75 12 4.75Z"
-      stroke={isHovered ? "#d97706" : "#64748b"}
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      fill={isHovered ? "#fcd34d" : "transparent"}
-      className="transition-all duration-200"
-    />
-    <path
-      d="M10 16.75H14"
-      stroke={isHovered ? "#d97706" : "#64748b"}
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      className="transition-colors duration-200"
-    />
-    <motion.path
-      d="M3.5 9H5.75"
-      stroke={isHovered ? "#d97706" : "#64748b"}
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      animate={{ opacity: isHovered ? 1 : 0 }}
-    />
-    <motion.path
-      d="M5 3.75L7.5 6"
-      stroke={isHovered ? "#d97706" : "#64748b"}
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      animate={{ opacity: isHovered ? 1 : 0 }}
-    />
-    <motion.path
-      d="M12 1.5V3.75"
-      stroke={isHovered ? "#d97706" : "#64748b"}
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      animate={{ opacity: isHovered ? 1 : 0 }}
-    />
-    <motion.path
-      d="M19 3.75L16.5 6"
-      stroke={isHovered ? "#d97706" : "#64748b"}
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      animate={{ opacity: isHovered ? 1 : 0 }}
-    />
-    <motion.path
-      d="M20.5 9H18.25"
-      stroke={isHovered ? "#d97706" : "#64748b"}
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      animate={{ opacity: isHovered ? 1 : 0 }}
-    />
-  </svg>
-);
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="none" viewBox="0 0 24 24">
+      <motion.path d="M9.497 10.877c-.95-1.233-2.534-1.565-3.724-.436-1.19 1.13-1.357 3.019-.423 4.355l4.147 4.454 4.146-4.454c.934-1.336.787-3.237-.423-4.355-1.21-1.117-2.774-.797-3.723.436Z" animate={{ fill: isHovered ? "#fda4af" : "transparent", stroke: isHovered ? "#e11d48" : "#64748b" }} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" transition={{ duration: 0.2 }} />
+      <motion.path d="M16.998 5.284c-.45-.584-1.2-.742-1.763-.207a1.606 1.606 0 0 0-.2 2.063l1.963 2.11 1.964-2.11c.443-.633.373-1.533-.2-2.063-.573-.529-1.314-.377-1.764.207Z" animate={{ fill: isHovered ? "#fda4af" : "transparent", stroke: isHovered ? "#e11d48" : "#64748b", opacity: isHovered ? 1 : 0, scale: isHovered ? 1 : 0.5 }} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" transition={{ duration: 0.3 }} />
+    </svg>
+  );
+};
+
+const CelebrateSVG = ({ isHovered, shouldReduceAnimations }: { isHovered: boolean; shouldReduceAnimations: boolean }) => {
+  if (shouldReduceAnimations) {
+    return (
+      <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M8.89062 9.28125L4.87279 17.7937C4.44606 18.628 5.29889 19.5379 6.16008 19.1671L14.6016 16.1875" stroke="#64748b" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" fill="transparent" />
+        <path d="M13.3196 10.9774C14.9594 12.8695 15.698 15.085 14.9691 15.9259C14.2403 16.7669 12.3202 15.9147 10.6804 14.0226C9.04057 12.1305 8.30205 9.91499 9.03085 9.07406C9.75966 8.23313 11.6798 9.08527 13.3196 10.9774Z" stroke="#64748b" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" fill="transparent" />
+        <path d="M11.5 5C11.5 5.27614 11.2761 5.5 11 5.5C10.7239 5.5 10.5 5.27614 10.5 5C10.5 4.72386 10.7239 4.5 11 4.5C11.2761 4.5 11.5 4.72386 11.5 5Z" stroke="#64748b" fill="transparent" />
+      </svg>
+    );
+  }
+
+  return (
+    <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M8.89062 9.28125L4.87279 17.7937C4.44606 18.628 5.29889 19.5379 6.16008 19.1671L14.6016 16.1875" stroke={isHovered ? "#4f46e5" : "#64748b"} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" fill={isHovered ? "#c7d2fe" : "transparent"} className="transition-all duration-200" />
+      <path d="M13.3196 10.9774C14.9594 12.8695 15.698 15.085 14.9691 15.9259C14.2403 16.7669 12.3202 15.9147 10.6804 14.0226C9.04057 12.1305 8.30205 9.91499 9.03085 9.07406C9.75966 8.23313 11.6798 9.08527 13.3196 10.9774Z" stroke={isHovered ? "#4f46e5" : "#64748b"} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" fill={isHovered ? "#c7d2fe" : "transparent"} className="transition-all duration-200" />
+      <motion.path d="M11.5 5C11.5 5.27614 11.2761 5.5 11 5.5C10.7239 5.5 10.5 5.27614 10.5 5C10.5 4.72386 10.7239 4.5 11 4.5C11.2761 4.5 11.5 4.72386 11.5 5Z" stroke={isHovered ? "#4f46e5" : "#64748b"} fill={isHovered ? "#eab308" : "transparent"} animate={{ opacity: isHovered ? 1 : 0.3 }} />
+      <motion.path d="M15.75 9.25L15.8787 9.12132C17.0503 7.94975 17.0503 6.05025 15.8787 4.87868L15.75 4.75" stroke={isHovered ? "#6366f1" : "#64748b"} strokeWidth="1.5" strokeLinecap="round" animate={{ opacity: isHovered ? 1 : 0 }} />
+      <motion.path d="M17 13.0001L17.2929 12.7072C17.6834 12.3167 18.3166 12.3167 18.7071 12.7072L19 13.0001" stroke={isHovered ? "#4f46e5" : "#64748b"} strokeWidth="1.5" strokeLinecap="round" animate={{ opacity: isHovered ? 1 : 0 }} />
+    </svg>
+  );
+};
+
+const InsightfulSVG = ({ isHovered, shouldReduceAnimations }: { isHovered: boolean; shouldReduceAnimations: boolean }) => {
+  if (shouldReduceAnimations) {
+    return (
+      <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M12 4.75C8.5 4.75 6.75 7.5 6.75 10C6.75 14 9.75 14.5 9.75 16V18.2505C9.75 18.8028 10.1977 19.25 10.75 19.25H13.25C13.8023 19.25 14.25 18.8028 14.25 18.2505V16C14.25 14.5 17.25 14 17.25 10C17.25 7.5 15.5 4.75 12 4.75Z" stroke="#64748b" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" fill="transparent" />
+        <path d="M10 16.75H14" stroke="#64748b" strokeWidth="1.5" strokeLinecap="round" />
+      </svg>
+    );
+  }
+
+  return (
+    <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <motion.path d="M12 4.75C8.5 4.75 6.75 7.5 6.75 10C6.75 14 9.75 14.5 9.75 16V18.2505C9.75 18.8028 10.1977 19.25 10.75 19.25H13.25C13.8023 19.25 14.25 18.8028 14.25 18.2505V16C14.25 14.5 17.25 14 17.25 10C17.25 7.5 15.5 4.75 12 4.75Z" stroke={isHovered ? "#d97706" : "#64748b"} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" fill={isHovered ? "#fcd34d" : "transparent"} className="transition-all duration-200" />
+      <path d="M10 16.75H14" stroke={isHovered ? "#d97706" : "#64748b"} strokeWidth="1.5" strokeLinecap="round" className="transition-colors duration-200" />
+      <motion.path d="M3.5 9H5.75" stroke={isHovered ? "#d97706" : "#64748b"} strokeWidth="1.5" strokeLinecap="round" animate={{ opacity: isHovered ? 1 : 0 }} />
+      <motion.path d="M5 3.75L7.5 6" stroke={isHovered ? "#d97706" : "#64748b"} strokeWidth="1.5" strokeLinecap="round" animate={{ opacity: isHovered ? 1 : 0 }} />
+      <motion.path d="M12 1.5V3.75" stroke={isHovered ? "#d97706" : "#64748b"} strokeWidth="1.5" strokeLinecap="round" animate={{ opacity: isHovered ? 1 : 0 }} />
+      <motion.path d="M19 3.75L16.5 6" stroke={isHovered ? "#d97706" : "#64748b"} strokeWidth="1.5" strokeLinecap="round" animate={{ opacity: isHovered ? 1 : 0 }} />
+      <motion.path d="M20.5 9H18.25" stroke={isHovered ? "#d97706" : "#64748b"} strokeWidth="1.5" strokeLinecap="round" animate={{ opacity: isHovered ? 1 : 0 }} />
+    </svg>
+  );
+};
 
 const REACTION_CONFIG: Record<
   ReactionType,
   {
-    Icon: React.FC<{ isHovered: boolean }>;
+    Icon: React.FC<{ isHovered: boolean; shouldReduceAnimations: boolean }>;
     label: string;
     bgColor: string;
     hoverBg: string;
@@ -230,22 +134,57 @@ export function ReactionBreakdown({
   reactions,
   delay = 0,
 }: ReactionBreakdownProps) {
+  const { shouldReduceAnimations } = usePerformanceMode();
   const [isHovered, setIsHovered] = useState(false);
-  const [hoveredReaction, setHoveredReaction] = useState<ReactionType | null>(
-    null
-  );
+  const [hoveredReaction, setHoveredReaction] = useState<ReactionType | null>(null);
   const total = Object.values(reactions).reduce((sum, count) => sum + count, 0);
 
+  const cardClassName = "group relative flex h-full flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary p-6 transition-all duration-300 hover:border-indigo-400 hover:bg-white";
+
+  // Mobile: Plain divs (zero animation overhead)
+  if (shouldReduceAnimations) {
+    return (
+      <div className={cardClassName}>
+        <div className="pointer-events-none absolute inset-0 z-10 rounded-2xl bg-gradient-to-tl from-indigo-400/20 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+
+        <div className="relative z-20 flex h-full flex-col">
+          <h2 className="mb-2 font-medium text-text-primary">Reactions</h2>
+          <p className="mb-4 text-3xl font-bold tabular-nums tracking-tight text-purple-primary">
+            {total.toLocaleString()}
+            <span className="ml-2 text-sm font-normal text-text-tertiary">total</span>
+          </p>
+
+          <div className="grid flex-1 grid-cols-2 gap-3">
+            {(Object.keys(REACTION_CONFIG) as ReactionType[]).map((type) => {
+              const count = reactions[type] || 0;
+              const config = REACTION_CONFIG[type];
+
+              return (
+                <div key={type} className={`flex flex-col items-center justify-center rounded-xl border border-border-primary/50 p-3 bg-white/50`}>
+                  <div className="mb-2">
+                    <config.Icon isHovered={false} shouldReduceAnimations={shouldReduceAnimations} />
+                  </div>
+                  <span className="text-lg font-semibold tabular-nums text-text-primary">{count.toLocaleString()}</span>
+                  <span className="text-xs text-text-tertiary">{config.label}</span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Desktop: Full Framer Motion animations
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5, delay, ease: "easeOut" }}
-      className="group relative flex h-full flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary p-6 transition-all duration-300 hover:border-indigo-400 hover:bg-white"
+      className={cardClassName}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
-      {/* Hover gradient overlay */}
       <div className="pointer-events-none absolute inset-0 z-10 rounded-2xl bg-gradient-to-tl from-indigo-400/20 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
 
       <div className="relative z-20 flex h-full flex-col">
@@ -256,59 +195,46 @@ export function ReactionBreakdown({
           className="mb-4 text-3xl font-bold tabular-nums tracking-tight text-purple-primary"
         >
           {total.toLocaleString()}
-          <span className="ml-2 text-sm font-normal text-text-tertiary">
-            total
-          </span>
+          <span className="ml-2 text-sm font-normal text-text-tertiary">total</span>
         </motion.p>
 
         <div className="grid flex-1 grid-cols-2 gap-3">
-          {(Object.keys(REACTION_CONFIG) as ReactionType[]).map(
-            (type, index) => {
-              const count = reactions[type] || 0;
-              const config = REACTION_CONFIG[type];
-              const isReactionHovered = hoveredReaction === type;
+          {(Object.keys(REACTION_CONFIG) as ReactionType[]).map((type, index) => {
+            const count = reactions[type] || 0;
+            const config = REACTION_CONFIG[type];
+            const isReactionHovered = hoveredReaction === type;
 
-              return (
+            return (
+              <motion.div
+                key={type}
+                initial={{ opacity: 0, scale: 0.9 }}
+                animate={{ opacity: 1, scale: 1 }}
+                transition={{ duration: 0.3, delay: delay + index * 0.1 }}
+                onMouseEnter={() => setHoveredReaction(type)}
+                onMouseLeave={() => setHoveredReaction(null)}
+                className={`flex flex-col items-center justify-center rounded-xl border border-border-primary/50 p-3 transition-all duration-200 ${
+                  isReactionHovered
+                    ? `${config.hoverBg} border-transparent`
+                    : "bg-white/50"
+                }`}
+              >
                 <motion.div
-                  key={type}
-                  initial={{ opacity: 0, scale: 0.9 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  transition={{ duration: 0.3, delay: delay + index * 0.1 }}
-                  onMouseEnter={() => setHoveredReaction(type)}
-                  onMouseLeave={() => setHoveredReaction(null)}
-                  className={`flex flex-col items-center justify-center rounded-xl border border-border-primary/50 p-3 transition-all duration-200 ${
-                    isReactionHovered
-                      ? `${config.hoverBg} border-transparent`
-                      : "bg-white/50"
-                  }`}
+                  animate={{ scale: isReactionHovered ? 1.15 : 1, y: isReactionHovered ? -2 : 0 }}
+                  transition={{ type: "spring", stiffness: 300, damping: 15 }}
+                  className="mb-2"
                 >
-                  <motion.div
-                    animate={{
-                      scale: isReactionHovered ? 1.15 : 1,
-                      y: isReactionHovered ? -2 : 0,
-                    }}
-                    transition={{
-                      type: "spring",
-                      stiffness: 300,
-                      damping: 15,
-                    }}
-                    className="mb-2"
-                  >
-                    <config.Icon isHovered={isReactionHovered} />
-                  </motion.div>
-                  <motion.span
-                    animate={{ scale: isReactionHovered ? 1.1 : 1 }}
-                    className="text-lg font-semibold tabular-nums text-text-primary"
-                  >
-                    {count.toLocaleString()}
-                  </motion.span>
-                  <span className="text-xs text-text-tertiary">
-                    {config.label}
-                  </span>
+                  <config.Icon isHovered={isReactionHovered} shouldReduceAnimations={shouldReduceAnimations} />
                 </motion.div>
-              );
-            }
-          )}
+                <motion.span
+                  animate={{ scale: isReactionHovered ? 1.1 : 1 }}
+                  className="text-lg font-semibold tabular-nums text-text-primary"
+                >
+                  {count.toLocaleString()}
+                </motion.span>
+                <span className="text-xs text-text-tertiary">{config.label}</span>
+              </motion.div>
+            );
+          })}
         </div>
       </div>
     </motion.div>

--- a/app/components/stats/SiteViewsCard.tsx
+++ b/app/components/stats/SiteViewsCard.tsx
@@ -115,7 +115,7 @@ function RisingWave({ isHovered, delay, shouldReduceAnimations }: { isHovered: b
           }
         />
 
-        {/* Glow line on hover - skip on mobile due to expensive blur filter */}
+        {/* Glow line on hover - skip for reduced motion users due to expensive blur filter */}
         {!shouldReduceAnimations && (
           <motion.path
             d={curvePath}
@@ -156,7 +156,7 @@ function RisingWave({ isHovered, delay, shouldReduceAnimations }: { isHovered: b
           }
         />
 
-        {/* Pulsing ring on endpoint - only on hover, skip on mobile */}
+        {/* Pulsing ring on endpoint - only on hover, skip for reduced motion users */}
         {!shouldReduceAnimations && (
           <motion.circle
             cx="310"
@@ -225,7 +225,7 @@ export function SiteViewsCard({ value, delay = 0 }: SiteViewsCardProps) {
   const [displayValue, setDisplayValue] = useState(0);
 
   useEffect(() => {
-    // Skip expensive counting animation on mobile/reduced motion
+    // Skip expensive counting animation for users with reduced motion preference
     if (shouldReduceAnimations) {
       setDisplayValue(value);
       return;

--- a/app/components/stats/SiteViewsCard.tsx
+++ b/app/components/stats/SiteViewsCard.tsx
@@ -27,6 +27,36 @@ function RisingWave({ isHovered, delay, shouldReduceAnimations }: { isHovered: b
   // Area fill extends well below viewBox to prevent cutoff on hover
   const areaPath = `${curvePath} L 310 150 L -10 150 Z`;
 
+  // Mobile: Static SVG (zero animation overhead)
+  if (shouldReduceAnimations) {
+    return (
+      <div className="pointer-events-none absolute inset-0 overflow-hidden rounded-2xl">
+        <svg
+          className="absolute inset-0 h-full w-full"
+          viewBox="0 0 320 130"
+          preserveAspectRatio="xMidYMid slice"
+        >
+          <defs>
+            <linearGradient id="waveGradient" x1="0%" y1="100%" x2="100%" y2="0%">
+              <stop offset="0%" stopColor="rgb(139, 92, 246)" stopOpacity="0.03" />
+              <stop offset="40%" stopColor="rgb(129, 140, 248)" stopOpacity="0.08" />
+              <stop offset="100%" stopColor="rgb(99, 102, 241)" stopOpacity="0.15" />
+            </linearGradient>
+            <linearGradient id="lineGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+              <stop offset="0%" stopColor="rgb(167, 139, 250)" stopOpacity="0.2" />
+              <stop offset="50%" stopColor="rgb(129, 140, 248)" stopOpacity="0.5" />
+              <stop offset="100%" stopColor="rgb(99, 102, 241)" stopOpacity="0.7" />
+            </linearGradient>
+          </defs>
+          <path d={areaPath} fill="url(#waveGradient)" />
+          <path d={curvePath} fill="none" stroke="url(#lineGrad)" strokeWidth={2} strokeLinecap="round" />
+          <circle cx="310" cy="10" r="4" fill="rgb(99, 102, 241)" />
+        </svg>
+      </div>
+    );
+  }
+
+  // Desktop: Full Framer Motion animations
   return (
     <div className="pointer-events-none absolute inset-0 overflow-hidden rounded-2xl">
       <svg
@@ -35,34 +65,26 @@ function RisingWave({ isHovered, delay, shouldReduceAnimations }: { isHovered: b
         preserveAspectRatio="xMidYMid slice"
       >
         <defs>
-          {/* Main gradient - flows from transparent to accent color */}
           <linearGradient id="waveGradient" x1="0%" y1="100%" x2="100%" y2="0%">
             <stop offset="0%" stopColor="rgb(139, 92, 246)" stopOpacity="0.03" />
             <stop offset="40%" stopColor="rgb(129, 140, 248)" stopOpacity="0.08" />
             <stop offset="100%" stopColor="rgb(99, 102, 241)" stopOpacity="0.15" />
           </linearGradient>
-
-          {/* Hover gradient - more vibrant */}
           <linearGradient id="waveGradientHover" x1="0%" y1="100%" x2="100%" y2="0%">
             <stop offset="0%" stopColor="rgb(139, 92, 246)" stopOpacity="0.08" />
             <stop offset="40%" stopColor="rgb(129, 140, 248)" stopOpacity="0.18" />
             <stop offset="100%" stopColor="rgb(99, 102, 241)" stopOpacity="0.28" />
           </linearGradient>
-
-          {/* Line gradient */}
           <linearGradient id="lineGrad" x1="0%" y1="0%" x2="100%" y2="0%">
             <stop offset="0%" stopColor="rgb(167, 139, 250)" stopOpacity="0.2" />
             <stop offset="50%" stopColor="rgb(129, 140, 248)" stopOpacity="0.5" />
             <stop offset="100%" stopColor="rgb(99, 102, 241)" stopOpacity="0.7" />
           </linearGradient>
-
           <linearGradient id="lineGradHover" x1="0%" y1="0%" x2="100%" y2="0%">
             <stop offset="0%" stopColor="rgb(167, 139, 250)" stopOpacity="0.4" />
             <stop offset="50%" stopColor="rgb(129, 140, 248)" stopOpacity="0.8" />
             <stop offset="100%" stopColor="rgb(99, 102, 241)" stopOpacity="1" />
           </linearGradient>
-
-          {/* Glow filter */}
           <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
             <feGaussianBlur stdDeviation="3" result="coloredBlur" />
             <feMerge>
@@ -72,112 +94,77 @@ function RisingWave({ isHovered, delay, shouldReduceAnimations }: { isHovered: b
           </filter>
         </defs>
 
-        {/* Gradient fill area */}
         <motion.path
           d={areaPath}
           fill={isHovered ? "url(#waveGradientHover)" : "url(#waveGradient)"}
-          initial={shouldReduceAnimations ? false : { opacity: 0, y: 20 }}
-          animate={{
-            opacity: 1,
-            y: shouldReduceAnimations ? 0 : (isHovered ? -3 : 0),
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: isHovered ? -3 : 0 }}
+          transition={{
+            opacity: { duration: 0.8, delay },
+            y: { duration: 0.3, ease: "easeOut" }
           }}
-          transition={
-            shouldReduceAnimations
-              ? { duration: 0 }
-              : {
-                  opacity: { duration: 0.8, delay },
-                  y: { duration: 0.3, ease: "easeOut" }
-                }
-          }
         />
 
-        {/* Main curve line */}
         <motion.path
           d={curvePath}
           fill="none"
           stroke={isHovered ? "url(#lineGradHover)" : "url(#lineGrad)"}
           strokeWidth={2}
           strokeLinecap="round"
-          initial={shouldReduceAnimations ? false : { pathLength: 0, opacity: 0 }}
-          animate={{
-            pathLength: 1,
-            opacity: 1,
-            y: shouldReduceAnimations ? 0 : (isHovered ? -3 : 0),
+          initial={{ pathLength: 0, opacity: 0 }}
+          animate={{ pathLength: 1, opacity: 1, y: isHovered ? -3 : 0 }}
+          transition={{
+            pathLength: { duration: 1.2, delay: delay + 0.2, ease: "easeOut" },
+            opacity: { duration: 0.5, delay },
+            y: { duration: 0.3, ease: "easeOut" }
           }}
-          transition={
-            shouldReduceAnimations
-              ? { duration: 0 }
-              : {
-                  pathLength: { duration: 1.2, delay: delay + 0.2, ease: "easeOut" },
-                  opacity: { duration: 0.5, delay },
-                  y: { duration: 0.3, ease: "easeOut" }
-                }
-          }
         />
 
-        {/* Glow line on hover - skip for reduced motion users due to expensive blur filter */}
-        {!shouldReduceAnimations && (
-          <motion.path
-            d={curvePath}
-            fill="none"
-            stroke="rgb(129, 140, 248)"
-            strokeWidth={4}
-            strokeLinecap="round"
-            filter="url(#glow)"
-            initial={{ opacity: 0 }}
-            animate={{
-              opacity: isHovered ? 0.4 : 0,
-              y: isHovered ? -3 : 0,
-            }}
-            transition={{ duration: 0.3 }}
-          />
-        )}
+        <motion.path
+          d={curvePath}
+          fill="none"
+          stroke="rgb(129, 140, 248)"
+          strokeWidth={4}
+          strokeLinecap="round"
+          filter="url(#glow)"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: isHovered ? 0.4 : 0, y: isHovered ? -3 : 0 }}
+          transition={{ duration: 0.3 }}
+        />
 
-        {/* Endpoint indicator */}
         <motion.circle
           cx="310"
           cy="10"
           r="4"
           fill="rgb(99, 102, 241)"
-          initial={shouldReduceAnimations ? false : { opacity: 0, scale: 0 }}
-          animate={{
-            opacity: shouldReduceAnimations ? 1 : (isHovered ? 1 : 0.5),
-            scale: 1,
-            y: shouldReduceAnimations ? 0 : (isHovered ? -3 : 0),
+          initial={{ opacity: 0, scale: 0 }}
+          animate={{ opacity: isHovered ? 1 : 0.5, scale: 1, y: isHovered ? -3 : 0 }}
+          transition={{
+            opacity: { duration: 0.2 },
+            scale: { duration: 0.5, delay: delay + 1 },
+            y: { duration: 0.3 }
           }}
-          transition={
-            shouldReduceAnimations
-              ? { duration: 0 }
-              : {
-                  opacity: { duration: 0.2 },
-                  scale: { duration: 0.5, delay: delay + 1 },
-                  y: { duration: 0.3 }
-                }
-          }
         />
 
-        {/* Pulsing ring on endpoint - only on hover, skip for reduced motion users */}
-        {!shouldReduceAnimations && (
-          <motion.circle
-            cx="310"
-            cy="10"
-            r="4"
-            fill="none"
-            stroke="rgb(99, 102, 241)"
-            strokeWidth="2"
-            initial={{ opacity: 0, scale: 1 }}
-            animate={{
-              opacity: isHovered ? [0.6, 0] : 0,
-              scale: isHovered ? [1, 2.5] : 1,
-              y: isHovered ? -3 : 0,
-            }}
-            transition={{
-              opacity: { duration: 1, repeat: Infinity },
-              scale: { duration: 1, repeat: Infinity },
-              y: { duration: 0.3 }
-            }}
-          />
-        )}
+        <motion.circle
+          cx="310"
+          cy="10"
+          r="4"
+          fill="none"
+          stroke="rgb(99, 102, 241)"
+          strokeWidth="2"
+          initial={{ opacity: 0, scale: 1 }}
+          animate={{
+            opacity: isHovered ? [0.6, 0] : 0,
+            scale: isHovered ? [1, 2.5] : 1,
+            y: isHovered ? -3 : 0,
+          }}
+          transition={{
+            opacity: { duration: 1, repeat: Infinity },
+            scale: { duration: 1, repeat: Infinity },
+            y: { duration: 0.3 }
+          }}
+        />
       </svg>
     </div>
   );
@@ -185,36 +172,42 @@ function RisingWave({ isHovered, delay, shouldReduceAnimations }: { isHovered: b
 
 // Small upward arrow icon
 function TrendArrow({ isHovered, shouldReduceAnimations }: { isHovered: boolean; shouldReduceAnimations: boolean }) {
+  const svg = (
+    <svg
+      className="h-4 w-4"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M7 17l5-5 5 5" />
+      <path d="M7 11l5-5 5 5" />
+    </svg>
+  );
+
+  // Mobile: Plain div (zero animation overhead)
+  if (shouldReduceAnimations) {
+    return (
+      <div className="flex items-center gap-1 text-emerald-500">
+        {svg}
+      </div>
+    );
+  }
+
+  // Desktop: Animated
   return (
     <motion.div
       className="flex items-center gap-1 text-emerald-500"
-      initial={shouldReduceAnimations ? false : { opacity: 0, x: -10 }}
-      animate={{
-        opacity: 1,
-        x: 0,
-        y: shouldReduceAnimations ? 0 : (isHovered ? -2 : 0),
+      initial={{ opacity: 0, x: -10 }}
+      animate={{ opacity: 1, x: 0, y: isHovered ? -2 : 0 }}
+      transition={{
+        opacity: { duration: 0.5, delay: 0.8 },
+        y: { duration: 0.2 }
       }}
-      transition={
-        shouldReduceAnimations
-          ? { duration: 0 }
-          : {
-              opacity: { duration: 0.5, delay: 0.8 },
-              y: { duration: 0.2 }
-            }
-      }
     >
-      <svg
-        className="h-4 w-4"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <path d="M7 17l5-5 5 5" />
-        <path d="M7 11l5-5 5 5" />
-      </svg>
+      {svg}
     </motion.div>
   );
 }
@@ -261,23 +254,40 @@ export function SiteViewsCard({ value, delay = 0 }: SiteViewsCardProps) {
     };
   }, [value, delay, shouldReduceAnimations]);
 
+  const cardClassName = "group relative flex h-full flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary p-6 transition-all duration-300 hover:border-indigo-400 hover:bg-white";
+
+  // Mobile: Plain div (zero animation overhead)
+  if (shouldReduceAnimations) {
+    return (
+      <div className={cardClassName}>
+        <div className="pointer-events-none absolute inset-0 z-10 rounded-2xl bg-gradient-to-tl from-indigo-400/20 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+        <RisingWave isHovered={isHovered} delay={delay} shouldReduceAnimations={shouldReduceAnimations} />
+
+        <div className="relative z-20 flex h-full flex-col">
+          <div className="mb-2 flex items-center gap-2">
+            <h2 className="font-medium text-text-primary">Total Site Views</h2>
+            <TrendArrow isHovered={isHovered} shouldReduceAnimations={shouldReduceAnimations} />
+          </div>
+
+          <p className="mt-auto text-3xl font-semibold tracking-tight text-purple-primary">
+            {displayValue.toLocaleString()}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Desktop: Full Framer Motion animations
   return (
     <motion.div
-      initial={shouldReduceAnimations ? false : { opacity: 0, y: 20 }}
+      initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={
-        shouldReduceAnimations
-          ? { duration: 0 }
-          : { duration: 0.5, delay, ease: "easeOut" }
-      }
-      className="group relative flex h-full flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary p-6 transition-all duration-300 hover:border-indigo-400 hover:bg-white"
-      onMouseEnter={() => !shouldReduceAnimations && setIsHovered(true)}
+      transition={{ duration: 0.5, delay, ease: "easeOut" }}
+      className={cardClassName}
+      onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
-      {/* Hover gradient overlay */}
       <div className="pointer-events-none absolute inset-0 z-10 rounded-2xl bg-gradient-to-tl from-indigo-400/20 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-
-      {/* Rising wave background */}
       <RisingWave isHovered={isHovered} delay={delay} shouldReduceAnimations={shouldReduceAnimations} />
 
       <div className="relative z-20 flex h-full flex-col">
@@ -287,9 +297,7 @@ export function SiteViewsCard({ value, delay = 0 }: SiteViewsCardProps) {
         </div>
 
         <motion.p
-          animate={
-            shouldReduceAnimations ? {} : { scale: isHovered ? 1.02 : 1 }
-          }
+          animate={{ scale: isHovered ? 1.02 : 1 }}
           transition={{ type: "spring", stiffness: 300, damping: 20 }}
           className="mt-auto text-3xl font-semibold tracking-tight text-purple-primary"
         >

--- a/app/components/stats/SiteViewsCard.tsx
+++ b/app/components/stats/SiteViewsCard.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "framer-motion";
 import { useEffect, useState } from "react";
+import { usePerformanceMode } from "@/app/hooks/usePerformanceMode";
 
 interface SiteViewsCardProps {
   value: number;
@@ -9,7 +10,7 @@ interface SiteViewsCardProps {
 }
 
 // Elegant rising wave visualization
-function RisingWave({ isHovered, delay }: { isHovered: boolean; delay: number }) {
+function RisingWave({ isHovered, delay, shouldReduceAnimations }: { isHovered: boolean; delay: number; shouldReduceAnimations: boolean }) {
   // Curve with natural variance - dips and climbs while trending upward
   // Starts lower-left, has organic ups and downs, ends at top-right
   const curvePath =
@@ -75,15 +76,19 @@ function RisingWave({ isHovered, delay }: { isHovered: boolean; delay: number })
         <motion.path
           d={areaPath}
           fill={isHovered ? "url(#waveGradientHover)" : "url(#waveGradient)"}
-          initial={{ opacity: 0, y: 20 }}
+          initial={shouldReduceAnimations ? false : { opacity: 0, y: 20 }}
           animate={{
             opacity: 1,
-            y: isHovered ? -3 : 0,
+            y: shouldReduceAnimations ? 0 : (isHovered ? -3 : 0),
           }}
-          transition={{
-            opacity: { duration: 0.8, delay },
-            y: { duration: 0.3, ease: "easeOut" }
-          }}
+          transition={
+            shouldReduceAnimations
+              ? { duration: 0 }
+              : {
+                  opacity: { duration: 0.8, delay },
+                  y: { duration: 0.3, ease: "easeOut" }
+                }
+          }
         />
 
         {/* Main curve line */}
@@ -93,34 +98,40 @@ function RisingWave({ isHovered, delay }: { isHovered: boolean; delay: number })
           stroke={isHovered ? "url(#lineGradHover)" : "url(#lineGrad)"}
           strokeWidth={2}
           strokeLinecap="round"
-          initial={{ pathLength: 0, opacity: 0 }}
+          initial={shouldReduceAnimations ? false : { pathLength: 0, opacity: 0 }}
           animate={{
             pathLength: 1,
             opacity: 1,
-            y: isHovered ? -3 : 0,
+            y: shouldReduceAnimations ? 0 : (isHovered ? -3 : 0),
           }}
-          transition={{
-            pathLength: { duration: 1.2, delay: delay + 0.2, ease: "easeOut" },
-            opacity: { duration: 0.5, delay },
-            y: { duration: 0.3, ease: "easeOut" }
-          }}
+          transition={
+            shouldReduceAnimations
+              ? { duration: 0 }
+              : {
+                  pathLength: { duration: 1.2, delay: delay + 0.2, ease: "easeOut" },
+                  opacity: { duration: 0.5, delay },
+                  y: { duration: 0.3, ease: "easeOut" }
+                }
+          }
         />
 
-        {/* Glow line on hover */}
-        <motion.path
-          d={curvePath}
-          fill="none"
-          stroke="rgb(129, 140, 248)"
-          strokeWidth={4}
-          strokeLinecap="round"
-          filter="url(#glow)"
-          initial={{ opacity: 0 }}
-          animate={{
-            opacity: isHovered ? 0.4 : 0,
-            y: isHovered ? -3 : 0,
-          }}
-          transition={{ duration: 0.3 }}
-        />
+        {/* Glow line on hover - skip on mobile due to expensive blur filter */}
+        {!shouldReduceAnimations && (
+          <motion.path
+            d={curvePath}
+            fill="none"
+            stroke="rgb(129, 140, 248)"
+            strokeWidth={4}
+            strokeLinecap="round"
+            filter="url(#glow)"
+            initial={{ opacity: 0 }}
+            animate={{
+              opacity: isHovered ? 0.4 : 0,
+              y: isHovered ? -3 : 0,
+            }}
+            transition={{ duration: 0.3 }}
+          />
+        )}
 
         {/* Endpoint indicator */}
         <motion.circle
@@ -128,59 +139,69 @@ function RisingWave({ isHovered, delay }: { isHovered: boolean; delay: number })
           cy="10"
           r="4"
           fill="rgb(99, 102, 241)"
-          initial={{ opacity: 0, scale: 0 }}
+          initial={shouldReduceAnimations ? false : { opacity: 0, scale: 0 }}
           animate={{
-            opacity: isHovered ? 1 : 0.5,
+            opacity: shouldReduceAnimations ? 1 : (isHovered ? 1 : 0.5),
             scale: 1,
-            y: isHovered ? -3 : 0,
+            y: shouldReduceAnimations ? 0 : (isHovered ? -3 : 0),
           }}
-          transition={{
-            opacity: { duration: 0.2 },
-            scale: { duration: 0.5, delay: delay + 1 },
-            y: { duration: 0.3 }
-          }}
+          transition={
+            shouldReduceAnimations
+              ? { duration: 0 }
+              : {
+                  opacity: { duration: 0.2 },
+                  scale: { duration: 0.5, delay: delay + 1 },
+                  y: { duration: 0.3 }
+                }
+          }
         />
 
-        {/* Pulsing ring on endpoint - only on hover */}
-        <motion.circle
-          cx="310"
-          cy="10"
-          r="4"
-          fill="none"
-          stroke="rgb(99, 102, 241)"
-          strokeWidth="2"
-          initial={{ opacity: 0, scale: 1 }}
-          animate={{
-            opacity: isHovered ? [0.6, 0] : 0,
-            scale: isHovered ? [1, 2.5] : 1,
-            y: isHovered ? -3 : 0,
-          }}
-          transition={{
-            opacity: { duration: 1, repeat: Infinity },
-            scale: { duration: 1, repeat: Infinity },
-            y: { duration: 0.3 }
-          }}
-        />
+        {/* Pulsing ring on endpoint - only on hover, skip on mobile */}
+        {!shouldReduceAnimations && (
+          <motion.circle
+            cx="310"
+            cy="10"
+            r="4"
+            fill="none"
+            stroke="rgb(99, 102, 241)"
+            strokeWidth="2"
+            initial={{ opacity: 0, scale: 1 }}
+            animate={{
+              opacity: isHovered ? [0.6, 0] : 0,
+              scale: isHovered ? [1, 2.5] : 1,
+              y: isHovered ? -3 : 0,
+            }}
+            transition={{
+              opacity: { duration: 1, repeat: Infinity },
+              scale: { duration: 1, repeat: Infinity },
+              y: { duration: 0.3 }
+            }}
+          />
+        )}
       </svg>
     </div>
   );
 }
 
 // Small upward arrow icon
-function TrendArrow({ isHovered }: { isHovered: boolean }) {
+function TrendArrow({ isHovered, shouldReduceAnimations }: { isHovered: boolean; shouldReduceAnimations: boolean }) {
   return (
     <motion.div
       className="flex items-center gap-1 text-emerald-500"
-      initial={{ opacity: 0, x: -10 }}
+      initial={shouldReduceAnimations ? false : { opacity: 0, x: -10 }}
       animate={{
         opacity: 1,
         x: 0,
-        y: isHovered ? -2 : 0,
+        y: shouldReduceAnimations ? 0 : (isHovered ? -2 : 0),
       }}
-      transition={{
-        opacity: { duration: 0.5, delay: 0.8 },
-        y: { duration: 0.2 }
-      }}
+      transition={
+        shouldReduceAnimations
+          ? { duration: 0 }
+          : {
+              opacity: { duration: 0.5, delay: 0.8 },
+              y: { duration: 0.2 }
+            }
+      }
     >
       <svg
         className="h-4 w-4"
@@ -199,19 +220,28 @@ function TrendArrow({ isHovered }: { isHovered: boolean }) {
 }
 
 export function SiteViewsCard({ value, delay = 0 }: SiteViewsCardProps) {
+  const { shouldReduceAnimations } = usePerformanceMode();
   const [isHovered, setIsHovered] = useState(false);
   const [displayValue, setDisplayValue] = useState(0);
 
   useEffect(() => {
+    // Skip expensive counting animation on mobile/reduced motion
+    if (shouldReduceAnimations) {
+      setDisplayValue(value);
+      return;
+    }
+
     const duration = 1500;
     const startTime = performance.now();
     const startDelay = delay * 1000;
+
+    let rafId: number;
 
     const animateCount = (currentTime: number) => {
       const elapsed = currentTime - startTime - startDelay;
 
       if (elapsed < 0) {
-        requestAnimationFrame(animateCount);
+        rafId = requestAnimationFrame(animateCount);
         return;
       }
 
@@ -220,36 +250,46 @@ export function SiteViewsCard({ value, delay = 0 }: SiteViewsCardProps) {
       setDisplayValue(Math.floor(eased * value));
 
       if (progress < 1) {
-        requestAnimationFrame(animateCount);
+        rafId = requestAnimationFrame(animateCount);
       }
     };
 
-    requestAnimationFrame(animateCount);
-  }, [value, delay]);
+    rafId = requestAnimationFrame(animateCount);
+
+    return () => {
+      if (rafId) cancelAnimationFrame(rafId);
+    };
+  }, [value, delay, shouldReduceAnimations]);
 
   return (
     <motion.div
-      initial={{ opacity: 0, y: 20 }}
+      initial={shouldReduceAnimations ? false : { opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.5, delay, ease: "easeOut" }}
+      transition={
+        shouldReduceAnimations
+          ? { duration: 0 }
+          : { duration: 0.5, delay, ease: "easeOut" }
+      }
       className="group relative flex h-full flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary p-6 transition-all duration-300 hover:border-indigo-400 hover:bg-white"
-      onMouseEnter={() => setIsHovered(true)}
+      onMouseEnter={() => !shouldReduceAnimations && setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
       {/* Hover gradient overlay */}
       <div className="pointer-events-none absolute inset-0 z-10 rounded-2xl bg-gradient-to-tl from-indigo-400/20 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
 
       {/* Rising wave background */}
-      <RisingWave isHovered={isHovered} delay={delay} />
+      <RisingWave isHovered={isHovered} delay={delay} shouldReduceAnimations={shouldReduceAnimations} />
 
       <div className="relative z-20 flex h-full flex-col">
         <div className="mb-2 flex items-center gap-2">
           <h2 className="font-medium text-text-primary">Total Site Views</h2>
-          <TrendArrow isHovered={isHovered} />
+          <TrendArrow isHovered={isHovered} shouldReduceAnimations={shouldReduceAnimations} />
         </div>
 
         <motion.p
-          animate={{ scale: isHovered ? 1.02 : 1 }}
+          animate={
+            shouldReduceAnimations ? {} : { scale: isHovered ? 1.02 : 1 }
+          }
           transition={{ type: "spring", stiffness: 300, damping: 20 }}
           className="mt-auto text-3xl font-semibold tracking-tight text-purple-primary"
         >

--- a/app/components/stats/StatCard.tsx
+++ b/app/components/stats/StatCard.tsx
@@ -67,17 +67,51 @@ export function StatCard({
     };
   }, [numericValue, animate, delay, shouldReduceAnimations]);
 
+  const cardClassName = `group relative flex h-full flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary p-6 transition-all duration-300 hover:border-indigo-400 hover:bg-white ${className}`;
+
+  // Mobile: Plain div (zero animation overhead)
+  if (shouldReduceAnimations) {
+    return (
+      <div className={cardClassName}>
+        {/* Hover gradient overlay */}
+        <div className="pointer-events-none absolute inset-0 z-10 rounded-2xl bg-gradient-to-tl from-indigo-400/20 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+
+        <div className="relative z-20 flex h-full flex-col">
+          {icon && (
+            <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-xl bg-purple-primary/10 text-purple-primary">
+              {icon}
+            </div>
+          )}
+
+          <h2 className="mb-2 font-medium text-text-primary">{label}</h2>
+
+          <p className="mt-auto text-3xl font-semibold tracking-tight text-purple-primary">
+            {numericValue !== null ? (
+              <>
+                {displayValue?.toLocaleString()}
+                {suffix && (
+                  <span className="ml-1 text-lg font-normal text-text-secondary">
+                    {suffix}
+                  </span>
+                )}
+              </>
+            ) : (
+              value
+            )}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Desktop: Full Framer Motion animations
   return (
     <motion.div
-      initial={shouldReduceAnimations ? false : { opacity: 0, y: 20 }}
+      initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={
-        shouldReduceAnimations
-          ? { duration: 0 }
-          : { duration: 0.5, delay, ease: "easeOut" }
-      }
-      className={`group relative flex h-full flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary p-6 transition-all duration-300 hover:border-indigo-400 hover:bg-white ${className}`}
-      onMouseEnter={() => !shouldReduceAnimations && setIsHovered(true)}
+      transition={{ duration: 0.5, delay, ease: "easeOut" }}
+      className={cardClassName}
+      onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
       {/* Hover gradient overlay */}
@@ -86,9 +120,7 @@ export function StatCard({
       <div className="relative z-20 flex h-full flex-col">
         {icon && (
           <motion.div
-            animate={
-              shouldReduceAnimations ? {} : { y: isHovered ? -4 : 0 }
-            }
+            animate={{ y: isHovered ? -4 : 0 }}
             transition={{ type: "spring", stiffness: 200, damping: 15 }}
             className="mb-3 flex h-10 w-10 items-center justify-center rounded-xl bg-purple-primary/10 text-purple-primary"
           >
@@ -99,9 +131,7 @@ export function StatCard({
         <h2 className="mb-2 font-medium text-text-primary">{label}</h2>
 
         <motion.p
-          animate={
-            shouldReduceAnimations ? {} : { scale: isHovered ? 1.02 : 1 }
-          }
+          animate={{ scale: isHovered ? 1.02 : 1 }}
           transition={{ type: "spring", stiffness: 300, damping: 20 }}
           className="mt-auto text-3xl font-semibold tracking-tight text-purple-primary"
         >

--- a/app/components/stats/StatCard.tsx
+++ b/app/components/stats/StatCard.tsx
@@ -31,7 +31,7 @@ export function StatCard({
   useEffect(() => {
     if (!animate || numericValue === null) return;
 
-    // Skip expensive counting animation on mobile/reduced motion
+    // Skip expensive counting animation for users with reduced motion preference
     if (shouldReduceAnimations) {
       setDisplayValue(numericValue);
       return;

--- a/app/components/stats/StatCard.tsx
+++ b/app/components/stats/StatCard.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "framer-motion";
 import { useEffect, useState } from "react";
+import { usePerformanceMode } from "@/app/hooks/usePerformanceMode";
 
 interface StatCardProps {
   label: string;
@@ -22,6 +23,7 @@ export function StatCard({
   delay = 0,
   className = "",
 }: StatCardProps) {
+  const { shouldReduceAnimations } = usePerformanceMode();
   const [isHovered, setIsHovered] = useState(false);
   const numericValue = typeof value === "number" ? value : null;
   const [displayValue, setDisplayValue] = useState(animate ? 0 : numericValue);
@@ -29,15 +31,23 @@ export function StatCard({
   useEffect(() => {
     if (!animate || numericValue === null) return;
 
+    // Skip expensive counting animation on mobile/reduced motion
+    if (shouldReduceAnimations) {
+      setDisplayValue(numericValue);
+      return;
+    }
+
     const duration = 1500;
     const startTime = performance.now();
     const startDelay = delay * 1000;
+
+    let rafId: number;
 
     const animateCount = (currentTime: number) => {
       const elapsed = currentTime - startTime - startDelay;
 
       if (elapsed < 0) {
-        requestAnimationFrame(animateCount);
+        rafId = requestAnimationFrame(animateCount);
         return;
       }
 
@@ -46,20 +56,28 @@ export function StatCard({
       setDisplayValue(Math.floor(eased * numericValue));
 
       if (progress < 1) {
-        requestAnimationFrame(animateCount);
+        rafId = requestAnimationFrame(animateCount);
       }
     };
 
-    requestAnimationFrame(animateCount);
-  }, [numericValue, animate, delay]);
+    rafId = requestAnimationFrame(animateCount);
+
+    return () => {
+      if (rafId) cancelAnimationFrame(rafId);
+    };
+  }, [numericValue, animate, delay, shouldReduceAnimations]);
 
   return (
     <motion.div
-      initial={{ opacity: 0, y: 20 }}
+      initial={shouldReduceAnimations ? false : { opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.5, delay, ease: "easeOut" }}
+      transition={
+        shouldReduceAnimations
+          ? { duration: 0 }
+          : { duration: 0.5, delay, ease: "easeOut" }
+      }
       className={`group relative flex h-full flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary p-6 transition-all duration-300 hover:border-indigo-400 hover:bg-white ${className}`}
-      onMouseEnter={() => setIsHovered(true)}
+      onMouseEnter={() => !shouldReduceAnimations && setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
       {/* Hover gradient overlay */}
@@ -68,7 +86,9 @@ export function StatCard({
       <div className="relative z-20 flex h-full flex-col">
         {icon && (
           <motion.div
-            animate={{ y: isHovered ? -4 : 0 }}
+            animate={
+              shouldReduceAnimations ? {} : { y: isHovered ? -4 : 0 }
+            }
             transition={{ type: "spring", stiffness: 200, damping: 15 }}
             className="mb-3 flex h-10 w-10 items-center justify-center rounded-xl bg-purple-primary/10 text-purple-primary"
           >
@@ -79,7 +99,9 @@ export function StatCard({
         <h2 className="mb-2 font-medium text-text-primary">{label}</h2>
 
         <motion.p
-          animate={{ scale: isHovered ? 1.02 : 1 }}
+          animate={
+            shouldReduceAnimations ? {} : { scale: isHovered ? 1.02 : 1 }
+          }
           transition={{ type: "spring", stiffness: 300, damping: 20 }}
           className="mt-auto text-3xl font-semibold tracking-tight text-purple-primary"
         >

--- a/app/components/stats/StatsPageHeader.tsx
+++ b/app/components/stats/StatsPageHeader.tsx
@@ -2,8 +2,36 @@
 
 import { motion } from "framer-motion";
 import { GridWrapper } from "../GridWrapper";
+import { usePerformanceMode } from "@/app/hooks/usePerformanceMode";
 
 export function StatsPageHeader() {
+  const { shouldReduceAnimations } = usePerformanceMode();
+
+  // Mobile: Plain divs (zero animation overhead)
+  if (shouldReduceAnimations) {
+    return (
+      <section>
+        <GridWrapper>
+          <div className="text-center">
+            <span className="text-sm font-medium text-indigo-600">Stats</span>
+          </div>
+        </GridWrapper>
+        <GridWrapper>
+          <h1 className="mx-auto mt-4 max-w-2xl text-balance text-center text-4xl font-medium leading-tight tracking-tighter text-text-primary md:text-5xl">
+            A peek behind the curtain
+          </h1>
+        </GridWrapper>
+        <GridWrapper>
+          <p className="mx-auto mt-4 max-w-xl text-center leading-8 text-text-secondary">
+            Numbers, metrics, and fun facts about this little corner of the
+            internet. Updated in real-time.
+          </p>
+        </GridWrapper>
+      </section>
+    );
+  }
+
+  // Desktop: Full Framer Motion animations
   return (
     <section>
       <GridWrapper>

--- a/app/components/stats/StatsPageWrapper.tsx
+++ b/app/components/stats/StatsPageWrapper.tsx
@@ -1,20 +1,22 @@
 "use client";
 
 import { MotionConfig } from "framer-motion";
+import { usePerformanceMode } from "@/app/hooks/usePerformanceMode";
 
 interface StatsPageWrapperProps {
   children: React.ReactNode;
 }
 
 /**
- * Wrapper component that respects user's motion preferences.
- * Uses Framer Motion's standard reducedMotion="user" setting,
- * which automatically disables animations for users with prefers-reduced-motion enabled.
- * Individual components optimize expensive RAF loops via usePerformanceMode hook.
+ * Wrapper component that optimizes animations for mobile performance and accessibility.
+ * Disables animations on mobile devices (<768px) OR when user has prefers-reduced-motion enabled.
+ * This hybrid approach balances performance with accessibility - production standard for animation-heavy apps.
  */
 export function StatsPageWrapper({ children }: StatsPageWrapperProps) {
+  const { shouldReduceAnimations } = usePerformanceMode();
+
   return (
-    <MotionConfig reducedMotion="user">
+    <MotionConfig reducedMotion={shouldReduceAnimations ? "always" : "user"}>
       {children}
     </MotionConfig>
   );

--- a/app/components/stats/StatsPageWrapper.tsx
+++ b/app/components/stats/StatsPageWrapper.tsx
@@ -8,52 +8,16 @@ interface StatsPageWrapperProps {
 }
 
 /**
- * Wrapper component that completely disables all Framer Motion animations on mobile
- * to prevent performance issues from too many simultaneous animations.
- *
- * Uses a multi-pronged approach:
- * 1. MotionConfig with reducedMotion="always" to disable Framer Motion animations
- * 2. CSS to force-disable any remaining animations and transitions
- * 3. Zero-duration transitions as a final catch-all
+ * Wrapper component that disables Framer Motion animations on mobile.
+ * Uses MotionConfig with reducedMotion="always" to skip all motion animations.
+ * Individual components handle RAF loop optimization via usePerformanceMode hook.
  */
 export function StatsPageWrapper({ children }: StatsPageWrapperProps) {
   const { shouldReduceAnimations } = usePerformanceMode();
 
   return (
-    <MotionConfig
-      reducedMotion={shouldReduceAnimations ? "always" : "user"}
-      transition={shouldReduceAnimations ? { duration: 0, delay: 0 } : undefined}
-    >
-      <div
-        className={shouldReduceAnimations ? "disable-all-animations" : ""}
-        style={
-          shouldReduceAnimations
-            ? {
-                // Force disable all CSS animations and transitions
-                // @ts-expect-error - CSS custom properties
-                "--motion-duration": "0s",
-                "--motion-delay": "0s",
-              }
-            : undefined
-        }
-      >
-        {children}
-      </div>
-      {/* Inject CSS to forcefully disable all animations on mobile */}
-      {shouldReduceAnimations && (
-        <style dangerouslySetInnerHTML={{
-          __html: `
-            .disable-all-animations *,
-            .disable-all-animations *::before,
-            .disable-all-animations *::after {
-              animation-duration: 0s !important;
-              animation-delay: 0s !important;
-              transition-duration: 0s !important;
-              transition-delay: 0s !important;
-            }
-          `
-        }} />
-      )}
+    <MotionConfig reducedMotion={shouldReduceAnimations ? "always" : "user"}>
+      {children}
     </MotionConfig>
   );
 }

--- a/app/components/stats/StatsPageWrapper.tsx
+++ b/app/components/stats/StatsPageWrapper.tsx
@@ -16,7 +16,10 @@ export function StatsPageWrapper({ children }: StatsPageWrapperProps) {
   const { shouldReduceAnimations } = usePerformanceMode();
 
   return (
-    <MotionConfig reducedMotion={shouldReduceAnimations ? "always" : "user"}>
+    <MotionConfig
+      reducedMotion={shouldReduceAnimations ? "always" : "user"}
+      transition={shouldReduceAnimations ? { duration: 0 } : undefined}
+    >
       {children}
     </MotionConfig>
   );

--- a/app/components/stats/StatsPageWrapper.tsx
+++ b/app/components/stats/StatsPageWrapper.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { MotionConfig } from "framer-motion";
+import { usePerformanceMode } from "@/app/hooks/usePerformanceMode";
+
+interface StatsPageWrapperProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Wrapper component that disables all Framer Motion animations on mobile
+ * to prevent performance issues from too many simultaneous animations.
+ */
+export function StatsPageWrapper({ children }: StatsPageWrapperProps) {
+  const { shouldReduceAnimations } = usePerformanceMode();
+
+  return (
+    <MotionConfig
+      transition={
+        shouldReduceAnimations
+          ? { duration: 0 }
+          : undefined
+      }
+      reducedMotion={shouldReduceAnimations ? "always" : "user"}
+    >
+      {children}
+    </MotionConfig>
+  );
+}

--- a/app/components/stats/StatsPageWrapper.tsx
+++ b/app/components/stats/StatsPageWrapper.tsx
@@ -8,22 +8,52 @@ interface StatsPageWrapperProps {
 }
 
 /**
- * Wrapper component that disables all Framer Motion animations on mobile
+ * Wrapper component that completely disables all Framer Motion animations on mobile
  * to prevent performance issues from too many simultaneous animations.
+ *
+ * Uses a multi-pronged approach:
+ * 1. MotionConfig with reducedMotion="always" to disable Framer Motion animations
+ * 2. CSS to force-disable any remaining animations and transitions
+ * 3. Zero-duration transitions as a final catch-all
  */
 export function StatsPageWrapper({ children }: StatsPageWrapperProps) {
   const { shouldReduceAnimations } = usePerformanceMode();
 
   return (
     <MotionConfig
-      transition={
-        shouldReduceAnimations
-          ? { duration: 0 }
-          : undefined
-      }
       reducedMotion={shouldReduceAnimations ? "always" : "user"}
+      transition={shouldReduceAnimations ? { duration: 0, delay: 0 } : undefined}
     >
-      {children}
+      <div
+        className={shouldReduceAnimations ? "disable-all-animations" : ""}
+        style={
+          shouldReduceAnimations
+            ? {
+                // Force disable all CSS animations and transitions
+                // @ts-expect-error - CSS custom properties
+                "--motion-duration": "0s",
+                "--motion-delay": "0s",
+              }
+            : undefined
+        }
+      >
+        {children}
+      </div>
+      {/* Inject CSS to forcefully disable all animations on mobile */}
+      {shouldReduceAnimations && (
+        <style dangerouslySetInnerHTML={{
+          __html: `
+            .disable-all-animations *,
+            .disable-all-animations *::before,
+            .disable-all-animations *::after {
+              animation-duration: 0s !important;
+              animation-delay: 0s !important;
+              transition-duration: 0s !important;
+              transition-delay: 0s !important;
+            }
+          `
+        }} />
+      )}
     </MotionConfig>
   );
 }

--- a/app/components/stats/StatsPageWrapper.tsx
+++ b/app/components/stats/StatsPageWrapper.tsx
@@ -1,25 +1,20 @@
 "use client";
 
 import { MotionConfig } from "framer-motion";
-import { usePerformanceMode } from "@/app/hooks/usePerformanceMode";
 
 interface StatsPageWrapperProps {
   children: React.ReactNode;
 }
 
 /**
- * Wrapper component that disables Framer Motion animations on mobile.
- * Uses MotionConfig with reducedMotion="always" to skip all motion animations.
- * Individual components handle RAF loop optimization via usePerformanceMode hook.
+ * Wrapper component that respects user's motion preferences.
+ * Uses Framer Motion's standard reducedMotion="user" setting,
+ * which automatically disables animations for users with prefers-reduced-motion enabled.
+ * Individual components optimize expensive RAF loops via usePerformanceMode hook.
  */
 export function StatsPageWrapper({ children }: StatsPageWrapperProps) {
-  const { shouldReduceAnimations } = usePerformanceMode();
-
   return (
-    <MotionConfig
-      reducedMotion={shouldReduceAnimations ? "always" : "user"}
-      transition={shouldReduceAnimations ? { duration: 0 } : undefined}
-    >
+    <MotionConfig reducedMotion="user">
       {children}
     </MotionConfig>
   );

--- a/app/components/stats/StatsSectionHeader.tsx
+++ b/app/components/stats/StatsSectionHeader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
+import { usePerformanceMode } from "@/app/hooks/usePerformanceMode";
 
 interface StatsSectionHeaderProps {
   title: string;
@@ -13,6 +14,21 @@ export function StatsSectionHeader({
   description,
   delay = 0,
 }: StatsSectionHeaderProps) {
+  const { shouldReduceAnimations } = usePerformanceMode();
+
+  // Mobile: Plain div (zero animation overhead)
+  if (shouldReduceAnimations) {
+    return (
+      <div className="mb-4">
+        <h2 className="text-lg font-semibold text-text-primary">{title}</h2>
+        {description && (
+          <p className="mt-0.5 text-sm text-text-secondary">{description}</p>
+        )}
+      </div>
+    );
+  }
+
+  // Desktop: Full Framer Motion animations
   return (
     <motion.div
       initial={{ opacity: 0, y: 10 }}

--- a/app/components/stats/TopArticlesCard.tsx
+++ b/app/components/stats/TopArticlesCard.tsx
@@ -4,6 +4,7 @@ import { motion } from "framer-motion";
 import Link from "next/link";
 import { useState } from "react";
 import type { ArticleMetric } from "@/app/lib/stats/types";
+import { usePerformanceMode } from "@/app/hooks/usePerformanceMode";
 
 interface TopArticlesCardProps {
   title: string;
@@ -18,15 +19,60 @@ export function TopArticlesCard({
   metricLabel,
   delay = 0,
 }: TopArticlesCardProps) {
+  const { shouldReduceAnimations } = usePerformanceMode();
   const [isHovered, setIsHovered] = useState(false);
   const [hoveredItem, setHoveredItem] = useState<number | null>(null);
 
+  const cardClassName = "group relative flex h-full flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary p-6 transition-all duration-300 hover:border-indigo-400 hover:bg-white";
+
+  // Mobile: Plain div (zero animation overhead)
+  if (shouldReduceAnimations) {
+    return (
+      <div className={cardClassName}>
+        {/* Hover gradient overlay */}
+        <div className="pointer-events-none absolute inset-0 z-10 rounded-2xl bg-gradient-to-tl from-indigo-400/20 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+
+        <div className="relative z-20 flex h-full flex-col">
+          <h2 className="mb-4 font-medium text-text-primary">{title}</h2>
+
+          {articles.length > 0 ? (
+            <ul className="flex flex-1 flex-col justify-center space-y-3">
+              {articles.map((article, index) => (
+                <li key={article.slug}>
+                  <Link
+                    href={`/blog/${article.slug}`}
+                    className="flex items-start justify-between gap-3"
+                  >
+                    <div className="flex items-start gap-3">
+                      <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-purple-primary/10 text-xs font-medium text-purple-primary">
+                        {index + 1}
+                      </span>
+                      <span className="line-clamp-2 text-sm leading-relaxed text-text-secondary">
+                        {article.title}
+                      </span>
+                    </div>
+                    <span className="shrink-0 text-xs font-semibold tabular-nums text-text-tertiary">
+                      {article.count.toLocaleString()}
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-text-tertiary">No data available yet</p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // Desktop: Full Framer Motion animations
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5, delay, ease: "easeOut" }}
-      className="group relative flex h-full flex-col overflow-hidden rounded-2xl border border-border-primary bg-bg-primary p-6 transition-all duration-300 hover:border-indigo-400 hover:bg-white"
+      className={cardClassName}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >

--- a/app/hooks/usePerformanceMode.ts
+++ b/app/hooks/usePerformanceMode.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface PerformanceMode {
+  isMobile: boolean;
+  prefersReducedMotion: boolean;
+  shouldReduceAnimations: boolean;
+}
+
+/**
+ * Hook to detect performance constraints and adjust animations accordingly.
+ * Returns flags for mobile detection and reduced motion preferences.
+ */
+export function usePerformanceMode(): PerformanceMode {
+  const [mode, setMode] = useState<PerformanceMode>({
+    isMobile: false,
+    prefersReducedMotion: false,
+    shouldReduceAnimations: false,
+  });
+
+  useEffect(() => {
+    // Check if viewport is mobile-sized
+    const checkMobile = () => {
+      const isMobile = window.innerWidth < 768;
+      const prefersReducedMotion = window.matchMedia(
+        "(prefers-reduced-motion: reduce)"
+      ).matches;
+
+      setMode({
+        isMobile,
+        prefersReducedMotion,
+        shouldReduceAnimations: isMobile || prefersReducedMotion,
+      });
+    };
+
+    checkMobile();
+
+    // Listen for viewport changes
+    window.addEventListener("resize", checkMobile);
+
+    // Listen for reduced motion preference changes
+    const motionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const handleMotionChange = () => checkMobile();
+
+    // Modern browsers
+    if (motionQuery.addEventListener) {
+      motionQuery.addEventListener("change", handleMotionChange);
+    } else {
+      // Fallback for older browsers
+      motionQuery.addListener(handleMotionChange);
+    }
+
+    return () => {
+      window.removeEventListener("resize", checkMobile);
+      if (motionQuery.removeEventListener) {
+        motionQuery.removeEventListener("change", handleMotionChange);
+      } else {
+        motionQuery.removeListener(handleMotionChange);
+      }
+    };
+  }, []);
+
+  return mode;
+}

--- a/app/hooks/usePerformanceMode.ts
+++ b/app/hooks/usePerformanceMode.ts
@@ -3,45 +3,31 @@
 import { useEffect, useState } from "react";
 
 interface PerformanceMode {
-  isMobile: boolean;
-  prefersReducedMotion: boolean;
   shouldReduceAnimations: boolean;
 }
 
 /**
- * Hook to detect performance constraints and adjust animations accordingly.
- * Returns flags for mobile detection and reduced motion preferences.
+ * Hook to detect user's reduced motion preference.
+ * Respects the prefers-reduced-motion accessibility setting.
+ * This follows Framer Motion's standard pattern for animation control.
  */
 export function usePerformanceMode(): PerformanceMode {
-  const [mode, setMode] = useState<PerformanceMode>({
-    isMobile: false,
-    prefersReducedMotion: false,
-    shouldReduceAnimations: false,
-  });
+  const [shouldReduceAnimations, setShouldReduceAnimations] = useState(false);
 
   useEffect(() => {
-    // Check if viewport is mobile-sized
-    const checkMobile = () => {
-      const isMobile = window.innerWidth < 768;
+    // Check user's reduced motion preference
+    const checkReducedMotion = () => {
       const prefersReducedMotion = window.matchMedia(
         "(prefers-reduced-motion: reduce)"
       ).matches;
-
-      setMode({
-        isMobile,
-        prefersReducedMotion,
-        shouldReduceAnimations: isMobile || prefersReducedMotion,
-      });
+      setShouldReduceAnimations(prefersReducedMotion);
     };
 
-    checkMobile();
-
-    // Listen for viewport changes
-    window.addEventListener("resize", checkMobile);
+    checkReducedMotion();
 
     // Listen for reduced motion preference changes
     const motionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
-    const handleMotionChange = () => checkMobile();
+    const handleMotionChange = () => checkReducedMotion();
 
     // Modern browsers
     if (motionQuery.addEventListener) {
@@ -52,7 +38,6 @@ export function usePerformanceMode(): PerformanceMode {
     }
 
     return () => {
-      window.removeEventListener("resize", checkMobile);
       if (motionQuery.removeEventListener) {
         motionQuery.removeEventListener("change", handleMotionChange);
       } else {
@@ -61,5 +46,5 @@ export function usePerformanceMode(): PerformanceMode {
     };
   }, []);
 
-  return mode;
+  return { shouldReduceAnimations };
 }

--- a/app/hooks/usePerformanceMode.ts
+++ b/app/hooks/usePerformanceMode.ts
@@ -3,48 +3,63 @@
 import { useEffect, useState } from "react";
 
 interface PerformanceMode {
+  isMobile: boolean;
+  prefersReducedMotion: boolean;
   shouldReduceAnimations: boolean;
 }
 
 /**
- * Hook to detect user's reduced motion preference.
- * Respects the prefers-reduced-motion accessibility setting.
- * This follows Framer Motion's standard pattern for animation control.
+ * Hook to detect performance constraints and accessibility preferences.
+ * Combines viewport detection (for performance) with prefers-reduced-motion (for accessibility).
+ * This is the production-standard hybrid approach used by apps like Stripe and Notion.
  */
 export function usePerformanceMode(): PerformanceMode {
-  const [shouldReduceAnimations, setShouldReduceAnimations] = useState(false);
+  const [mode, setMode] = useState<PerformanceMode>({
+    isMobile: false,
+    prefersReducedMotion: false,
+    shouldReduceAnimations: false,
+  });
 
   useEffect(() => {
-    // Check user's reduced motion preference
-    const checkReducedMotion = () => {
+    const checkPerformanceMode = () => {
+      const isMobile = window.innerWidth < 768;
       const prefersReducedMotion = window.matchMedia(
         "(prefers-reduced-motion: reduce)"
       ).matches;
-      setShouldReduceAnimations(prefersReducedMotion);
+
+      setMode({
+        isMobile,
+        prefersReducedMotion,
+        // Reduce animations for EITHER mobile performance OR accessibility
+        shouldReduceAnimations: isMobile || prefersReducedMotion,
+      });
     };
 
-    checkReducedMotion();
+    checkPerformanceMode();
+
+    // Listen for viewport changes
+    window.addEventListener("resize", checkPerformanceMode);
 
     // Listen for reduced motion preference changes
     const motionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
-    const handleMotionChange = () => checkReducedMotion();
 
     // Modern browsers
     if (motionQuery.addEventListener) {
-      motionQuery.addEventListener("change", handleMotionChange);
+      motionQuery.addEventListener("change", checkPerformanceMode);
     } else {
       // Fallback for older browsers
-      motionQuery.addListener(handleMotionChange);
+      motionQuery.addListener(checkPerformanceMode);
     }
 
     return () => {
+      window.removeEventListener("resize", checkPerformanceMode);
       if (motionQuery.removeEventListener) {
-        motionQuery.removeEventListener("change", handleMotionChange);
+        motionQuery.removeEventListener("change", checkPerformanceMode);
       } else {
-        motionQuery.removeListener(handleMotionChange);
+        motionQuery.removeListener(checkPerformanceMode);
       }
     };
   }, []);
 
-  return { shouldReduceAnimations };
+  return mode;
 }

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -19,6 +19,7 @@ import { GitHubStatsCard } from "@/app/components/stats/GitHubStatsCard";
 import { ContributionGraphCard } from "@/app/components/stats/ContributionGraphCard";
 import { LighthouseScoreCard } from "@/app/components/stats/LighthouseScoreCard";
 import { GridWrapper } from "@/app/components/GridWrapper";
+import { StatsPageWrapper } from "@/app/components/stats/StatsPageWrapper";
 
 export const metadata: Metadata = {
   title: "Stats | Braydon Coyer",
@@ -52,8 +53,9 @@ export default async function StatsPage() {
   const mostViewedArticle = serverStats.topViewedArticles[0];
 
   return (
-    <div className="mt-14 space-y-12 pb-16 md:mt-16 md:space-y-16">
-      <StatsPageHeader />
+    <StatsPageWrapper>
+      <div className="mt-14 space-y-12 pb-16 md:mt-16 md:space-y-16">
+        <StatsPageHeader />
 
       {/* Blog Stats Section */}
       <section>
@@ -250,6 +252,7 @@ export default async function StatsPage() {
           </GridWrapper>
         </section>
       )}
-    </div>
+      </div>
+    </StatsPageWrapper>
   );
 }


### PR DESCRIPTION
Addresses performance issues causing animations to feel laggy on mobile devices:

- Created usePerformanceMode hook to detect mobile viewports and reduced motion preferences
- Optimized StatCard: Skip expensive RAF counting animations on mobile
- Optimized SiteViewsCard: Remove expensive SVG blur filters and infinite pulsing animations on mobile
- Optimized ContributionGraphCard: Disable staggered animations for 364 cells on mobile
- Added proper RAF cleanup with cancelAnimationFrame
- Disabled spring physics hover animations on mobile
- All animations now respect prefers-reduced-motion accessibility setting

Performance improvements:
- Eliminated 10+ simultaneous requestAnimationFrame loops on mobile
- Removed expensive feGaussianBlur SVG filters on mobile
- Reduced 364 individual staggered animations to instant rendering on mobile
- Disabled unnecessary hover state calculations on mobile devices