### PR TITLE
Fix footer year to display dynamically

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 import { SocialPill } from "./SocialPill";
 import { GridWrapper } from "./GridWrapper";


### PR DESCRIPTION
Convert Footer component to client component to ensure the copyright year
always reflects the current year in the browser, fixing the issue where it
was showing 2025 instead of 2026.