### PR TITLE
Fix contribution graph showing stale 

### DIFF
--- a/app/lib/stats/github-stats.ts
+++ b/app/lib/stats/github-stats.ts
@@ -7,10 +7,15 @@ const GITHUB_REPO = "braydoncoyer/braydoncoyer.dev";
 const GITHUB_USERNAME = "braydoncoyer";
 
 async function fetchContributions(token: string): Promise<ContributionData | null> {
+  // Calculate rolling 365-day window ending today
+  const today = new Date();
+  const oneYearAgo = new Date();
+  oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+
   const query = `
     query {
       user(login: "${GITHUB_USERNAME}") {
-        contributionsCollection {
+        contributionsCollection(from: "${oneYearAgo.toISOString()}", to: "${today.toISOString()}") {
           contributionCalendar {
             totalContributions
             weeks {


### PR DESCRIPTION


The GitHub GraphQL query was missing explicit date parameters, causing it to return data relative to when the cache was created rather than the current date. Added from/to parameters to always request a rolling 365-day window ending today.