### PR TITLE
Implement 410 Gone responses for crawler error URLs

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,23 @@
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 
+// URLs that should return 410 Gone (crawler errors, never existed)
+const GONE_URLS = [
+  "/blog/themeContext",
+  "/blog/README.template.md",
+  "/blog/greeting",
+  "/blog/m",
+  "/blog/hello-world!",
+];
+
 export async function middleware(request: NextRequest) {
+  const pathname = request.nextUrl.pathname;
+
+  // Return 410 Gone for URLs that never existed (tells Google to stop crawling)
+  if (GONE_URLS.includes(pathname)) {
+    return new NextResponse("Gone", { status: 410 });
+  }
+
   let response = NextResponse.next({
     request: {
       headers: request.headers,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,8 +8,44 @@ if (!process.env.VELITE_STARTED && (isDev || isBuild)) {
 
 /** @type {import('next').NextConfig} */
 const config = {
+  trailingSlash: false,
   async redirects() {
     return [
+      // Handle trailing slashes on blog posts (Google Search Console 404s)
+      {
+        source: "/blog/:slug/",
+        destination: "/blog/:slug",
+        permanent: true,
+      },
+      // Handle www to non-www (if needed by hosting)
+      {
+        source: "/index.html",
+        destination: "/",
+        permanent: true,
+      },
+      // Newsletter page redirect (no dedicated page exists)
+      {
+        source: "/newsletter",
+        destination: "/",
+        permanent: true,
+      },
+      {
+        source: "/newsletter/",
+        destination: "/",
+        permanent: true,
+      },
+      // Fix apostrophe encoding in URL
+      {
+        source: "/blog/you-don't-need-a-cs-degree-to-land-a-web-development-job",
+        destination: "/blog/you-dont-need-a-cs-degree-to-land-a-web-development-job",
+        permanent: true,
+      },
+      // Fix truncated Gatsby URL
+      {
+        source: "/blog/gatsbyconf-2021-gatsby-v3-and-the",
+        destination: "/blog/gatsbyconf-2021-gatsby-v3-and-the-new-gatsby-image",
+        permanent: true,
+      },
       {
         source: "/archives/v1",
         destination: "https://wizardly-payne-b3707b.netlify.app/",

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,44 +8,8 @@ if (!process.env.VELITE_STARTED && (isDev || isBuild)) {
 
 /** @type {import('next').NextConfig} */
 const config = {
-  trailingSlash: false,
   async redirects() {
     return [
-      // Handle trailing slashes on blog posts (Google Search Console 404s)
-      {
-        source: "/blog/:slug/",
-        destination: "/blog/:slug",
-        permanent: true,
-      },
-      // Handle www to non-www (if needed by hosting)
-      {
-        source: "/index.html",
-        destination: "/",
-        permanent: true,
-      },
-      // Newsletter page redirect (no dedicated page exists)
-      {
-        source: "/newsletter",
-        destination: "/",
-        permanent: true,
-      },
-      {
-        source: "/newsletter/",
-        destination: "/",
-        permanent: true,
-      },
-      // Fix apostrophe encoding in URL
-      {
-        source: "/blog/you-don't-need-a-cs-degree-to-land-a-web-development-job",
-        destination: "/blog/you-dont-need-a-cs-degree-to-land-a-web-development-job",
-        permanent: true,
-      },
-      // Fix truncated Gatsby URL
-      {
-        source: "/blog/gatsbyconf-2021-gatsby-v3-and-the",
-        destination: "/blog/gatsbyconf-2021-gatsby-v3-and-the-new-gatsby-image",
-        permanent: true,
-      },
       {
         source: "/archives/v1",
         destination: "https://wizardly-payne-b3707b.netlify.app/",


### PR DESCRIPTION
Implement 410 Gone HTTP responses for URLs that never existed or are no longer valid. This tells search engines to stop crawling these URLs instead of treating them as 404 errors.

The middleware now handles a specific list of crawler error URLs by returning 410 Gone status, improving SEO by properly communicating intentional resource removal to search engines.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>